### PR TITLE
Improve workflow suggestion by folder

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/run_workflow.html
+++ b/equipment_booking_app/workflow_automation/templates/run_workflow.html
@@ -13,8 +13,8 @@
                 Suggested Workflow: {{ suggested_workflow.name }} — Use this?
                 <form method="post" class="d-inline">
                     {% csrf_token %}
-                    <button type="submit" name="accept_suggested" value="1" class="btn btn-sm btn-success ml-2">Yes</button>
-                    <button type="submit" name="reject_suggested" value="1" class="btn btn-sm btn-danger ml-1">No</button>
+                    <button type="submit" name="accept_suggested" value="1" class="btn btn-sm btn-success ml-2">✅ Yes</button>
+                    <button type="submit" name="reject_suggested" value="1" class="btn btn-sm btn-danger ml-1">❌ No</button>
                 </form>
             </div>
         {% endif %}

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
-from . import file_utils
+from django.contrib.auth.models import User
+from .models import Workflow
+from . import file_utils, views
 import os
 import tempfile
 
@@ -29,5 +31,16 @@ class FileUtilsTests(TestCase):
             self.assertEqual(len(paths), 1)
             self.assertTrue(paths[0].startswith(os.path.join(out_root, "SITE")))
             self.assertTrue(os.path.exists(paths[0] + ".convert"))
+
+
+class WorkflowMatchTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="tester")
+        self.wf = Workflow.objects.create(name="SL-SL-SR-101A", created_by=self.user)
+
+    def test_match_workflow_from_path(self):
+        path = os.path.join("/tmp", "foo", "SL-SL-SR-101A")
+        match = views.match_workflow_from_path(path, self.user)
+        self.assertEqual(match, self.wf)
 
 

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -490,9 +490,9 @@ def use_shared_workflow(request, workflow_id):
     return redirect('my_workflows')
 
 
-def suggest_workflow_for_folder(path, user):
-    """Return a workflow whose name or tags match the folder path."""
-    segments = [s for s in os.path.normpath(path).split(os.sep) if s][-3:]
+def match_workflow_from_path(path, user, depth=3):
+    """Return a workflow whose name or tags match segments of the path."""
+    segments = [s for s in os.path.normpath(path).split(os.sep) if s][-depth:]
     query_base = Workflow.objects.filter(created_by=user)
     for seg in reversed(segments):
         q = Q(name__icontains=seg)
@@ -546,7 +546,7 @@ def run_workflow(request):
                 request.session["input_folder"] = input_folder
                 request.session["output_folder"] = output_folder
                 confirm = True
-                suggested_workflow = suggest_workflow_for_folder(output_folder, request.user)
+                suggested_workflow = match_workflow_from_path(output_folder, request.user)
                 if suggested_workflow:
                     request.session["suggested_wf_id"] = suggested_workflow.id
             StepFormSet = StepSettingsFormSet(request.POST)


### PR DESCRIPTION
## Summary
- match workflow names or tags based on output folder path
- show explicit "✅ Yes" and "❌ No" buttons when suggesting a workflow
- test matching helper

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687d367c66fc83258ed09f28e5a2341d