### PR TITLE
Add modular automation tools

### DIFF
--- a/equipment_booking_app/utils/converter.py
+++ b/equipment_booking_app/utils/converter.py
@@ -1,0 +1,21 @@
+import os
+from workflow_automation import file_utils
+
+
+def convert_directory(path: str, fmt: str):
+    """Convert all video files in a directory to the given format."""
+    converted = []
+    for name in os.listdir(path):
+        src = os.path.join(path, name)
+        if not os.path.isfile(src):
+            continue
+        base = os.path.splitext(src)[0]
+        dst = f"{base}.{fmt}"
+        file_utils.convert_video(src, dst, fmt)
+        if dst != src:
+            try:
+                os.remove(src)
+            except OSError:
+                pass
+        converted.append(os.path.basename(dst))
+    return converted

--- a/equipment_booking_app/utils/rename.py
+++ b/equipment_booking_app/utils/rename.py
@@ -1,0 +1,27 @@
+import os
+from workflow_automation import file_utils
+
+
+def rename_directory(path: str, pattern: str = ""):
+    """Rename files in a directory using smart rules or a custom pattern."""
+    site_code = file_utils.parse_site_code(path)
+    renamed = []
+    for idx, name in enumerate(os.listdir(path), 1):
+        src = os.path.join(path, name)
+        if not os.path.isfile(src):
+            continue
+        if pattern:
+            timestamp = file_utils.extract_timestamp(src)
+            ext = os.path.splitext(src)[1]
+            new_name = pattern.format(
+                site=site_code,
+                index=idx,
+                timestamp=timestamp,
+                ext=ext,
+            )
+            dst = os.path.join(path, new_name)
+            os.rename(src, dst)
+        else:
+            dst = file_utils.smart_rename(src, site_code)
+        renamed.append(os.path.basename(dst))
+    return renamed

--- a/equipment_booking_app/utils/zipper.py
+++ b/equipment_booking_app/utils/zipper.py
@@ -1,0 +1,12 @@
+import os
+import zipfile
+
+
+def zip_directory(path: str, output_zip: str):
+    """Zip the contents of a directory."""
+    with zipfile.ZipFile(output_zip, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for root, dirs, files in os.walk(path):
+            for name in files:
+                fp = os.path.join(root, name)
+                zf.write(fp, os.path.relpath(fp, path))
+    return output_zip

--- a/equipment_booking_app/workflow_automation/forms.py
+++ b/equipment_booking_app/workflow_automation/forms.py
@@ -203,3 +203,18 @@ class StepSettingsForm(forms.Form):
 
 StepSettingsFormSet = forms.formset_factory(StepSettingsForm, extra=0)
 
+
+
+class RenameToolForm(forms.Form):
+    input_path = forms.CharField(label="Input Folder", max_length=255)
+    rename_pattern = forms.CharField(label="Rename Pattern", required=False)
+
+
+class ConvertToolForm(forms.Form):
+    input_path = forms.CharField(label="Input Folder", max_length=255)
+    format = forms.ChoiceField(label="Format", choices=[("mp4", "MP4"), ("avi", "AVI")])
+
+
+class ZipToolForm(forms.Form):
+    input_path = forms.CharField(label="Input Folder", max_length=255)
+    output_zip = forms.CharField(label="Output Zip", max_length=255)

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_convert.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_convert.html
@@ -1,0 +1,20 @@
+{% extends 'workflow_automation/base.html' %}
+
+{% block content %}
+<h2 class="text-center mb-4">Run Convert Tool</h2>
+<div class="card p-4 w-75 mx-auto mb-4" style="color:#192d38;">
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" class="btn btn-primary">Run Convert</button>
+    </form>
+    {% if files %}
+    <h4 class="mt-4">Converted Files</h4>
+    <ul>
+        {% for f in files %}
+        <li>{{ f }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</div>
+{% endblock %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
@@ -1,0 +1,20 @@
+{% extends 'workflow_automation/base.html' %}
+
+{% block content %}
+<h2 class="text-center mb-4">Run Rename Tool</h2>
+<div class="card p-4 w-75 mx-auto mb-4" style="color:#192d38;">
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" class="btn btn-primary">Run Rename</button>
+    </form>
+    {% if files %}
+    <h4 class="mt-4">Renamed Files</h4>
+    <ul>
+        {% for f in files %}
+        <li>{{ f }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</div>
+{% endblock %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_zip.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_zip.html
@@ -1,0 +1,16 @@
+{% extends 'workflow_automation/base.html' %}
+
+{% block content %}
+<h2 class="text-center mb-4">Run Zip Tool</h2>
+<div class="card p-4 w-75 mx-auto mb-4" style="color:#192d38;">
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" class="btn btn-primary">Run Zip</button>
+    </form>
+    {% if zip_path %}
+    <h4 class="mt-4">Created Zip</h4>
+    <p>{{ zip_path }}</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_dashboard.html
@@ -4,6 +4,9 @@
 <h2 class="text-center mb-4">Automation Workflows</h2>
 <a href="{% url 'create_workflow' %}" class="btn btn-primary mb-3">Create New Workflow</a>
 <a href="{% url 'run_workflow' %}" class="btn btn-secondary mb-3">Run Workflow</a>
+<a href="{% url 'run_rename' %}" class="btn btn-secondary mb-3">Run Rename Tool</a>
+<a href="{% url 'run_convert' %}" class="btn btn-secondary mb-3">Run Convert Tool</a>
+<a href="{% url 'run_zip' %}" class="btn btn-secondary mb-3">Run Zip Tool</a>
 
 {% if workflows %}
     <ul class="list-group">

--- a/equipment_booking_app/workflow_automation/urls.py
+++ b/equipment_booking_app/workflow_automation/urls.py
@@ -26,4 +26,7 @@ urlpatterns = [
     path('workflows/create/', views.create_workflow, name='create_workflow'),
     path('workflows/run/', views.run_workflow, name='run_workflow'),
     path('workflows/progress/<int:run_id>/', views.workflow_progress, name='workflow_progress'),
+    path('run-rename/', views.run_rename_view, name='run_rename'),
+    path('run-convert/', views.run_convert_view, name='run_convert'),
+    path('run-zip/', views.run_zip_view, name='run_zip'),
 ]

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -29,9 +29,13 @@ from .forms import (
     WorkflowStepFormSet,
     RunWorkflowForm,
     StepSettingsFormSet,
+    RenameToolForm,
+    ConvertToolForm,
+    ZipToolForm,
 )
 
 from .workflow_runner import WorkflowRunner
+from utils import rename, converter, zipper
 
 # Number of allowed failed attempts before locking an account
 LOCKOUT_THRESHOLD = 5
@@ -645,3 +649,40 @@ def workflow_progress(request, run_id):
         "workflow_automation/workflow_progress.html",
         {"run": run, "logs": runner.logs, "done": done, "run_mode": run_mode},
     )
+
+
+@login_required
+def run_rename_view(request):
+    form = RenameToolForm(request.POST or None)
+    files = []
+    if request.method == "POST" and form.is_valid():
+        input_path = form.cleaned_data["input_path"]
+        pattern = form.cleaned_data.get("rename_pattern", "")
+        files = rename.rename_directory(input_path, pattern)
+        messages.success(request, "Rename completed")
+    return render(request, "workflow_automation/run_rename.html", {"form": form, "files": files})
+
+
+@login_required
+def run_convert_view(request):
+    form = ConvertToolForm(request.POST or None)
+    files = []
+    if request.method == "POST" and form.is_valid():
+        input_path = form.cleaned_data["input_path"]
+        fmt = form.cleaned_data["format"]
+        files = converter.convert_directory(input_path, fmt)
+        messages.success(request, "Conversion completed")
+    return render(request, "workflow_automation/run_convert.html", {"form": form, "files": files})
+
+
+@login_required
+def run_zip_view(request):
+    form = ZipToolForm(request.POST or None)
+    zip_path = None
+    if request.method == "POST" and form.is_valid():
+        input_path = form.cleaned_data["input_path"]
+        output_zip = form.cleaned_data["output_zip"]
+        zip_path = zipper.zip_directory(input_path, output_zip)
+        messages.success(request, "Zip created")
+    return render(request, "workflow_automation/run_zip.html", {"form": form, "zip_path": zip_path})
+


### PR DESCRIPTION
## Summary
- add utils package with rename, converter, and zipper helpers
- expose Rename, Convert, and Zip operations via new views
- include forms for each tool and templates for running them
- link tool views from Automation Workflows dashboard

## Testing
- `pip install -r requirements.txt`
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e38d28d608325b14635facd7cc328