### PR TITLE
Add folder picker for rename workflow

### DIFF
--- a/equipment_booking_app/utils/rename.py
+++ b/equipment_booking_app/utils/rename.py
@@ -25,3 +25,32 @@ def rename_directory(path: str, pattern: str = ""):
             dst = file_utils.smart_rename(src, site_code)
         renamed.append(os.path.basename(dst))
     return renamed
+
+
+def run_rename(raw_data_folder: str, output_folder: str, user_initials: str, full_name: str):
+    """Rename media in ``raw_data_folder`` and move to ``output_folder``.
+
+    The function validates the input folder contains files, performs a smart
+    rename using :func:`rename_directory`, then moves the renamed files to the
+    output folder. ``user_initials`` and ``full_name`` are accepted for future
+    extensions but are currently unused.
+    """
+
+    if not os.path.isdir(raw_data_folder):
+        raise ValueError("RAW data folder does not exist")
+
+    files = [f for f in os.listdir(raw_data_folder) if os.path.isfile(os.path.join(raw_data_folder, f))]
+    if not files:
+        raise ValueError("RAW data folder contains no files")
+
+    os.makedirs(output_folder, exist_ok=True)
+
+    renamed = rename_directory(raw_data_folder)
+    results = []
+    for name in renamed:
+        src = os.path.join(raw_data_folder, name)
+        dst = os.path.join(output_folder, name)
+        os.replace(src, dst)
+        results.append(dst)
+
+    return results

--- a/equipment_booking_app/workflow_automation/forms.py
+++ b/equipment_booking_app/workflow_automation/forms.py
@@ -206,7 +206,10 @@ StepSettingsFormSet = forms.formset_factory(StepSettingsForm, extra=0)
 
 
 class RenameToolForm(forms.Form):
-    input_path = forms.CharField(label="Input Folder", max_length=255)
+    raw_data_folder = forms.CharField(label="RAW Data Folder", max_length=255)
+    output_folder = forms.CharField(label="Output Folder", max_length=255)
+    user_initials = forms.CharField(label="Your Initials", max_length=10)
+    full_name = forms.CharField(label="Full Name", max_length=100)
     rename_pattern = forms.CharField(label="Rename Pattern", required=False)
 
 

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
@@ -5,7 +5,37 @@
 <div class="card p-4 w-75 mx-auto mb-4" style="color:#192d38;">
     <form method="post">
         {% csrf_token %}
-        {{ form.as_p }}
+        <div style="display:none;">
+            {{ form.raw_data_folder }}
+            {{ form.output_folder }}
+        </div>
+
+        <div class="form-group">
+            <label>Select RAW Data Folder</label><br>
+            <input type="file" id="raw_folder_picker" webkitdirectory directory multiple style="display:none;">
+            <button type="button" class="btn btn-secondary" id="raw_folder_btn">Browse</button>
+            <span id="raw_folder_label" class="ml-2">{{ raw_folder }}</span>
+        </div>
+
+        <div class="form-group">
+            <label>Select Output Folder</label><br>
+            <input type="file" id="output_folder_picker" webkitdirectory directory multiple style="display:none;">
+            <button type="button" class="btn btn-secondary" id="output_folder_btn">Browse</button>
+            <span id="output_folder_label" class="ml-2"></span>
+        </div>
+
+        <div class="form-group">
+            <label for="id_user_initials">Your Initials</label>
+            {{ form.user_initials }}
+        </div>
+        <div class="form-group">
+            <label for="id_full_name">Full Name</label>
+            {{ form.full_name }}
+        </div>
+        <div class="form-group">
+            <label for="id_rename_pattern">Rename Pattern</label>
+            {{ form.rename_pattern }}
+        </div>
         <button type="submit" class="btn btn-primary">Run Rename</button>
     </form>
     {% if files %}
@@ -18,3 +48,30 @@
     {% endif %}
 </div>
 {% endblock %}
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+    const rawPicker = document.getElementById('raw_folder_picker');
+    document.getElementById('raw_folder_btn').addEventListener('click', function(){
+        rawPicker.click();
+    });
+    rawPicker.addEventListener('change', function(){
+        if (this.files.length){
+            const path = this.files[0].webkitRelativePath.split('/')[0];
+            document.getElementById('id_raw_data_folder').value = path;
+            document.getElementById('raw_folder_label').textContent = path;
+        }
+    });
+
+    const outputPicker = document.getElementById('output_folder_picker');
+    document.getElementById('output_folder_btn').addEventListener('click', function(){
+        outputPicker.click();
+    });
+    outputPicker.addEventListener('change', function(){
+        if (this.files.length){
+            const path = this.files[0].webkitRelativePath.split('/')[0];
+            document.getElementById('id_output_folder').value = path;
+            document.getElementById('output_folder_label').textContent = path;
+        }
+    });
+});
+</script>

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -655,12 +655,27 @@ def workflow_progress(request, run_id):
 def run_rename_view(request):
     form = RenameToolForm(request.POST or None)
     files = []
+    selected_folder = ""
     if request.method == "POST" and form.is_valid():
-        input_path = form.cleaned_data["input_path"]
-        pattern = form.cleaned_data.get("rename_pattern", "")
-        files = rename.rename_directory(input_path, pattern)
-        messages.success(request, "Rename completed")
-    return render(request, "workflow_automation/run_rename.html", {"form": form, "files": files})
+        raw_folder = form.cleaned_data["raw_data_folder"]
+        output_folder = form.cleaned_data["output_folder"]
+        initials = form.cleaned_data["user_initials"]
+        full_name = form.cleaned_data["full_name"]
+
+        if not os.path.isdir(raw_folder) or not any(
+            os.path.isfile(os.path.join(raw_folder, f)) for f in os.listdir(raw_folder)
+        ):
+            form.add_error("raw_data_folder", "Selected folder has no valid files")
+        else:
+            files = rename.run_rename(raw_folder, output_folder, initials, full_name)
+            messages.success(request, "Rename completed")
+            selected_folder = raw_folder
+
+    return render(
+        request,
+        "workflow_automation/run_rename.html",
+        {"form": form, "files": files, "raw_folder": selected_folder},
+    )
 
 
 @login_required


### PR DESCRIPTION
## Summary
- add more inputs to RenameToolForm including RAW folder path
- implement `run_rename` helper to rename and move files
- validate folder contents and run from Django view
- add directory pickers with JS for rename view

## Testing
- `python -m py_compile equipment_booking_app/workflow_automation/forms.py equipment_booking_app/utils/rename.py equipment_booking_app/workflow_automation/views.py`
- `find equipment_booking_app -name '*.py' -not -path '*/venv/*' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_687e3dbc93ec8325b6bb3c89e801ba9d