### PR TITLE
Add filename convention helper

### DIFF
--- a/equipment_booking_app/workflow_automation/file_utils.py
+++ b/equipment_booking_app/workflow_automation/file_utils.py
@@ -145,3 +145,50 @@ def organize_files(files, output_root, site_code="", target_folder=""):
             open(dst + ".convert", "w").close()
         paths.append(dst)
     return paths
+
+
+def generate_next_filename(folder_path: str, extension: str = "") -> str | None:
+    """Return the next sequential file name using existing zone patterns.
+
+    The function searches ``folder_path`` along with its parent and grandparent
+    directories (including all subfolders) for files matching the typical zone
+    naming convention ``PREFIX-3V-XXXX.ext``. The highest numeric suffix found
+    is incremented and combined with the detected prefix. ``extension`` is
+    appended to the returned name. If no matching files are found, ``None`` is
+    returned.
+    """
+
+    search_roots = [os.path.abspath(folder_path)]
+    parent = os.path.dirname(search_roots[0])
+    if parent and parent != search_roots[0]:
+        search_roots.append(parent)
+        grand = os.path.dirname(parent)
+        if grand and grand != parent:
+            search_roots.append(grand)
+
+    pattern = re.compile(r"^([A-Za-z0-9-]+-3V)-(\d{4})", re.IGNORECASE)
+    prefix_map = {}
+
+    for root in search_roots:
+        if not os.path.isdir(root):
+            continue
+        for dirpath, _, files in os.walk(root):
+            for fname in files:
+                match = pattern.match(fname)
+                if match:
+                    prefix, idx = match.group(1), int(match.group(2))
+                    if idx > prefix_map.get(prefix, -1):
+                        prefix_map[prefix] = idx
+
+    if not prefix_map:
+        return None
+
+    prefix, cur_idx = sorted(prefix_map.items(), key=lambda x: x[1], reverse=True)[0]
+    next_idx = cur_idx + 1
+    candidate = f"{prefix}-{next_idx:04d}{extension}"
+
+    while os.path.exists(os.path.join(folder_path, candidate)):
+        next_idx += 1
+        candidate = f"{prefix}-{next_idx:04d}{extension}"
+
+    return candidate

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
@@ -27,6 +27,26 @@
                 </div>
             </div>
         {% endif %}
+        {% if proposed_name %}
+            <div class="alert alert-info mt-2">
+                Proposed file name: {{ proposed_name }}. Accept?
+                <form method="post" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" name="accept_filename" value="1" class="btn btn-sm btn-success ml-2">Yes</button>
+                    <button type="submit" name="reject_filename" value="1" class="btn btn-sm btn-danger ml-1">No</button>
+                </form>
+            </div>
+        {% endif %}
+        {% if manual_override %}
+            <div class="alert alert-warning mt-2">
+                Enter preferred base file name:
+                <form method="post" class="form-inline mt-1">
+                    {% csrf_token %}
+                    <input type="text" name="manual_name" class="form-control mr-2">
+                    <button type="submit" name="override_filename" value="1" class="btn btn-primary">Set</button>
+                </form>
+            </div>
+        {% endif %}
     {% endif %}
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -67,3 +67,15 @@ class RunWorkflowNoMatchTests(TestCase):
         self.assertTrue(any("No workflow matched" in str(m) for m in messages))
 
 
+class GenerateNextFilenameTests(TestCase):
+    def test_generate_next_filename(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "sub"), exist_ok=True)
+            existing = os.path.join(tmp, "sub", "SL-SL-SR-011-A-3V-0001.mp4")
+            with open(existing, "wb") as fh:
+                fh.write(b"\x00")
+
+            name = file_utils.generate_next_filename(os.path.join(tmp, "sub"), ".mp4")
+            self.assertEqual(name, "SL-SL-SR-011-A-3V-0002.mp4")
+
+

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -36,6 +36,7 @@ from .forms import (
 
 from .workflow_runner import WorkflowRunner
 from utils import rename, converter, zipper
+from . import file_utils
 
 # Number of allowed failed attempts before locking an account
 LOCKOUT_THRESHOLD = 5
@@ -536,9 +537,37 @@ def run_workflow(request):
     confirm = False
     input_folder = output_folder = ""
     suggested_workflow = None
+    proposed_name = request.session.get("proposed_name")
+    manual_override = False
 
     if request.method == "POST":
-        if "accept_suggested" in request.POST:
+        if "accept_filename" in request.POST:
+            input_folder = request.session.get("input_folder", "")
+            output_folder = request.session.get("output_folder", "")
+            confirm = True
+            form = RunWorkflowForm(
+                initial={"workflow": workflow, "input_path": input_folder, "output_path": output_folder},
+                user=request.user,
+            )
+            StepFormSet = StepSettingsFormSet()
+            request.session["final_name"] = request.session.get("proposed_name")
+        elif "reject_filename" in request.POST:
+            input_folder = request.session.get("input_folder", "")
+            output_folder = request.session.get("output_folder", "")
+            confirm = True
+            manual_override = True
+            form = RunWorkflowForm(user=request.user)
+            StepFormSet = StepSettingsFormSet()
+        elif "override_filename" in request.POST:
+            manual_name = request.POST.get("manual_name")
+            if manual_name:
+                request.session["final_name"] = manual_name
+            input_folder = request.session.get("input_folder", "")
+            output_folder = request.session.get("output_folder", "")
+            confirm = True
+            form = RunWorkflowForm(user=request.user)
+            StepFormSet = StepSettingsFormSet()
+        elif "accept_suggested" in request.POST:
             wf_id = request.session.get("suggested_wf_id")
             if wf_id:
                 workflow = get_object_or_404(Workflow, id=wf_id, created_by=request.user)
@@ -574,6 +603,17 @@ def run_workflow(request):
                     request.session["suggested_wf_id"] = suggested_workflow.id
                 else:
                     messages.info(request, "No workflow matched — please choose an option.")
+
+                files = []
+                if os.path.isdir(input_folder):
+                    files = [
+                        f for f in os.listdir(input_folder)
+                        if os.path.isfile(os.path.join(input_folder, f))
+                    ]
+                ext = os.path.splitext(files[0])[1] if files else ""
+                proposed_name = file_utils.generate_next_filename(output_folder, ext)
+                if proposed_name:
+                    request.session["proposed_name"] = proposed_name
             StepFormSet = StepSettingsFormSet(request.POST)
     else:
         form = RunWorkflowForm(user=request.user)
@@ -583,6 +623,8 @@ def run_workflow(request):
                 suggested_workflow = Workflow.objects.get(id=request.session["suggested_wf_id"], created_by=request.user)
             except Workflow.DoesNotExist:
                 suggested_workflow = None
+        if request.session.get("proposed_name"):
+            proposed_name = request.session["proposed_name"]
 
     step_pairs = list(zip(workflow.steps.all(), StepFormSet)) if workflow else []
 
@@ -598,6 +640,8 @@ def run_workflow(request):
             "input_folder": input_folder,
             "output_folder": output_folder,
             "suggested_workflow": suggested_workflow,
+            "proposed_name": proposed_name,
+            "manual_override": manual_override,
         },
     )
 


### PR DESCRIPTION
## Summary
- generate a next filename based on nearby zone patterns
- prompt the user in the workflow runner with the proposed name
- allow manual override via the UI
- test the new utility

## Testing
- `PYTHONPATH=$(pwd)/equipment_booking_app python equipment_booking_app/manage.py test workflow_automation.tests -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e44dd6d1c8325a96663419f82b746