### PR TITLE
Add project folder setup step

### DIFF
--- a/equipment_booking_app/workflow_automation/file_utils.py
+++ b/equipment_booking_app/workflow_automation/file_utils.py
@@ -192,3 +192,37 @@ def generate_next_filename(folder_path: str, extension: str = "") -> str | None:
         candidate = f"{prefix}-{next_idx:04d}{extension}"
 
     return candidate
+
+
+def copy_template_structure(template_root: str, dest_root: str, *,
+                            subfolders: list[str] | None = None,
+                            initials: str = "") -> str:
+    """Copy a folder hierarchy from ``template_root`` into ``dest_root``.
+
+    Directory names containing ``YYMMDD`` are replaced with today's date in
+    ``DDMMYY`` format. ``CH`` tokens are replaced with ``initials``. Only the
+    specified ``subfolders`` are copied when provided.
+    """
+    date_token = datetime.now().strftime("%d%m%y")
+
+    if subfolders is None:
+        subfolders = [d for d in os.listdir(template_root)
+                      if os.path.isdir(os.path.join(template_root, d))]
+
+    for sub in subfolders:
+        src_base = os.path.join(template_root, sub)
+        if not os.path.isdir(src_base):
+            continue
+
+        for dirpath, dirnames, filenames in os.walk(src_base):
+            rel = os.path.relpath(dirpath, src_base)
+            replaced = rel.replace("YYMMDD", date_token).replace("CH", initials)
+            target_dir = os.path.join(dest_root, sub, replaced)
+            os.makedirs(target_dir, exist_ok=True)
+
+            for fname in filenames:
+                dest_name = fname.replace("YYMMDD", date_token).replace("CH", initials)
+                shutil.copy2(os.path.join(dirpath, fname),
+                             os.path.join(target_dir, dest_name))
+
+    return dest_root

--- a/equipment_booking_app/workflow_automation/forms.py
+++ b/equipment_booking_app/workflow_automation/forms.py
@@ -199,6 +199,17 @@ class StepSettingsForm(forms.Form):
                 label="Target Folder",
                 required=False,
             )
+        elif step_type == "setup_structure":
+            self.fields["raw_data_folder"] = forms.CharField(
+                label="Raw Data Folder",
+                required=True,
+                widget=forms.HiddenInput(),
+            )
+            self.fields["full_structure"] = forms.BooleanField(
+                label="Generate Full Structure",
+                required=False,
+                initial=False,
+            )
 
 
 StepSettingsFormSet = forms.formset_factory(StepSettingsForm, extra=0)

--- a/equipment_booking_app/workflow_automation/models.py
+++ b/equipment_booking_app/workflow_automation/models.py
@@ -124,6 +124,7 @@ class Workflow(models.Model):
 
 class WorkflowStep(models.Model):
     STEP_CHOICES = [
+        ("setup_structure", "Setup Folder Structure"),
         ("convert_360_video", "Convert Media"),
         ("rename", "Rename Files"),
         ("remove_audio", "Remove Audio"),

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/create_workflow.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/create_workflow.html
@@ -15,6 +15,14 @@
     <h4>Tasks</h4>
     <div class="mb-3">
         <div class="form-check">
+            <input class="form-check-input task-toggle" data-target="setup_settings" type="checkbox" id="setup_cb" name="include_setup_structure">
+            <label class="form-check-label" for="setup_cb">Setup folder structure</label>
+        </div>
+        <div id="setup_settings" class="ml-4 mt-2" style="display:none;">
+            <input type="number" name="order_setup_structure" min="1" class="form-control" placeholder="Order">
+        </div>
+
+        <div class="form-check">
             <input class="form-check-input task-toggle" data-target="convert_settings" type="checkbox" id="convert_cb" name="include_convert_360_video">
             <label class="form-check-label" for="convert_cb">Convert media</label>
         </div>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
@@ -105,7 +105,20 @@
             {% for step, step_form in step_pairs %}
                 <div class="border rounded p-2 mb-2">
                     <strong>{{ step.get_step_type_display }}</strong>
-                    {{ step_form.as_p }}
+                    {% if step.step_type == 'setup_structure' %}
+                        <div class="form-group">
+                            <label>Select RAW Data Folder</label><br>
+                            <input type="file" id="raw_picker_{{ forloop.counter }}" webkitdirectory directory multiple style="display:none;">
+                            <button type="button" class="btn btn-secondary" onclick="document.getElementById('raw_picker_{{ forloop.counter }}').click()">Browse</button>
+                            <span id="raw_label_{{ forloop.counter }}" class="ml-2"></span>
+                            {{ step_form.raw_data_folder }}
+                        </div>
+                        <div class="form-check mt-2">
+                            {{ step_form.full_structure }} {{ step_form.full_structure.label_tag }}
+                        </div>
+                    {% else %}
+                        {{ step_form.as_p }}
+                    {% endif %}
                 </div>
             {% endfor %}
         {% endif %}
@@ -167,6 +180,17 @@ document.addEventListener('DOMContentLoaded', function(){
             document.getElementById('id_output_path').value = path;
             document.getElementById('output_folder_label').textContent = path;
         }
+    });
+
+    document.querySelectorAll('input[id^="raw_picker_"]').forEach(function(picker){
+        picker.addEventListener('change', function(){
+            if (this.files.length) {
+                const path = this.files[0].webkitRelativePath.split('/')[0];
+                const counter = this.id.split('_')[2];
+                document.getElementById('id_form-' + (counter - 1) + '-raw_data_folder').value = path;
+                document.getElementById('raw_label_' + counter).textContent = path;
+            }
+        });
     });
 });
 </script>

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -395,6 +395,7 @@ def workflow_dashboard(request):
 @login_required
 def create_workflow(request):
     step_codes = [
+        "setup_structure",
         "convert_360_video",
         "rename",
         "remove_audio",

--- a/equipment_booking_app/workflow_automation/workflow_runner.py
+++ b/equipment_booking_app/workflow_automation/workflow_runner.py
@@ -1,6 +1,8 @@
 """Utility to execute a saved workflow step by step."""
 
 import os
+import shutil
+from datetime import datetime
 from . import file_utils
 
 
@@ -63,6 +65,45 @@ class WorkflowRunner:
 
     def run_default(self, config):
         return "Step completed"
+
+    def run_setup_structure(self, config):
+        raw_folder = config.get("raw_data_folder")
+        full = config.get("full_structure", False)
+
+        template_base = (
+            "P:/Energy/RealityCapture/Sellafield/Sellafield/00-00-00 Template/Project Files"
+        )
+        project_root = os.path.join(self.output_path, self.project_code, "Project Files")
+        os.makedirs(project_root, exist_ok=True)
+
+        video_steps = {"convert_360_video", "remove_audio", "trim"}
+        if full:
+            subfolders = None
+        elif any(s.step_type in video_steps for s in self.workflow.steps.all()):
+            subfolders = ["3V - 360 Videos"]
+        else:
+            subfolders = ["3P - 360 Photos"]
+
+        file_utils.copy_template_structure(
+            template_base,
+            project_root,
+            subfolders=subfolders,
+            initials=self.initials or "",
+        )
+
+        date_token = datetime.now().strftime("%d%m%y")
+        raw_dest = project_root
+        if subfolders:
+            raw_dest = os.path.join(project_root, subfolders[0])
+        raw_dest = os.path.join(raw_dest, f"{date_token}{self.initials}", "RAW Data")
+        os.makedirs(raw_dest, exist_ok=True)
+        if raw_folder and os.path.isdir(raw_folder):
+            for fname in os.listdir(raw_folder):
+                src = os.path.join(raw_folder, fname)
+                if os.path.isfile(src):
+                    shutil.move(src, os.path.join(raw_dest, fname))
+
+        return f"Structure created at {raw_dest}"
 
     def run_rename(self, config):
         pattern = config.get("rename_pattern", "")


### PR DESCRIPTION
## Summary
- allow workflows to setup folder structures from a master template
- let users pick a RAW data folder and choose full structure generation
- move selected files into newly created `RAW Data` folder

## Testing
- `python manage.py test workflow_automation`

------
https://chatgpt.com/codex/tasks/task_e_687e4710c5fc8325a74b669f0ae4a89a