### PR TITLE
Add video QA review step

### DIFF
--- a/equipment_booking_app/workflow_automation/file_utils.py
+++ b/equipment_booking_app/workflow_automation/file_utils.py
@@ -79,6 +79,24 @@ def trim_video(src: str, dst: str, start: int, end: int) -> str:
     return dst
 
 
+def generate_video_preview(src: str, dst: str) -> str:
+    """Create a single preview frame from ``src`` using ffmpeg."""
+    if ffmpeg_exists():
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            src,
+            "-ss",
+            "00:00:02",
+            "-frames:v",
+            "1",
+            dst,
+        ]
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return dst
+
+
 PHOTO_EXTS = {".jpg", ".jpeg", ".png", ".dng", ".insp"}
 VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".insv"}
 PHOTO_360_EXTS = {".insp"}

--- a/equipment_booking_app/workflow_automation/forms.py
+++ b/equipment_booking_app/workflow_automation/forms.py
@@ -235,3 +235,10 @@ class ConvertToolForm(forms.Form):
 class ZipToolForm(forms.Form):
     input_path = forms.CharField(label="Input Folder", max_length=255)
     output_zip = forms.CharField(label="Output Zip", max_length=255)
+
+
+class VideoReviewForm(forms.Form):
+    zone_id = forms.CharField(label="Zone ID", max_length=50)
+    flag_manual_edit = forms.BooleanField(
+        label="Flag for Manual Edit", required=False
+    )

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/video_review.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/video_review.html
@@ -1,0 +1,18 @@
+{% extends 'workflow_automation/base.html' %}
+
+{% block content %}
+<h2 class="text-center mb-4">Video QA Review</h2>
+<div class="w-75 mx-auto" style="color:#192d38;">
+    <img src="{{ preview_url }}" class="img-fluid mb-3" alt="Video preview">
+    <form method="post">
+        {% csrf_token %}
+        <div class="form-group">
+            {{ form.zone_id.label_tag }} {{ form.zone_id }}
+        </div>
+        <div class="form-check mb-3">
+            {{ form.flag_manual_edit }} {{ form.flag_manual_edit.label_tag }}
+        </div>
+        <button type="submit" class="btn btn-primary">Confirm and Continue</button>
+    </form>
+</div>
+{% endblock %}

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -32,6 +32,7 @@ from .forms import (
     RenameToolForm,
     ConvertToolForm,
     ZipToolForm,
+    VideoReviewForm,
 )
 
 from .workflow_runner import WorkflowRunner
@@ -590,7 +591,7 @@ def run_workflow(request):
 
                     configs = [sf.cleaned_data for sf in step_forms]
 
-                    if pause:
+                    if pause or workflow.qa_video_review:
                         request.session[f"run_{run.id}_configs"] = configs
                         request.session[f"run_{run.id}_index"] = 0
                         request.session.modified = True
@@ -739,6 +740,8 @@ def workflow_progress(request, run_id):
     step_index = request.session.get(f"run_{run_id}_index", 0)
     run_mode = "pause" if run.pause_between_steps else "run_all"
 
+    review_state = request.session.get(f"run_{run_id}_review")
+
     runner = WorkflowRunner(
         run.workflow,
         run.input_path,
@@ -752,11 +755,40 @@ def workflow_progress(request, run_id):
     runner.current_step = step_index
     runner.logs = run.log.splitlines() if run.log else []
 
+    if review_state:
+        runner.conversion_index = review_state.get("index", 0)
+        runner.review_pending = True
+        runner.review_image = review_state.get("image", "")
+        runner.review_file = review_state.get("file", "")
+
+    if runner.review_pending:
+        form = VideoReviewForm(request.POST or None)
+        if request.method == "POST" and form.is_valid():
+            zone = form.cleaned_data["zone_id"]
+            flag = form.cleaned_data["flag_manual_edit"]
+            msg = f"Reviewed {os.path.basename(runner.review_file)} - Zone {zone}"
+            if flag:
+                msg += " (flagged for manual edit)"
+            runner.logs.append(msg)
+            runner.review_pending = False
+            request.session.pop(f"run_{run_id}_review", None)
+            run.log = "\n".join(runner.logs)
+            run.save()
+            if run.completed_at is None:
+                if run_mode == "run_all":
+                    runner.run_all()
+                else:
+                    runner.run_next()
+        else:
+            return render(
+                request,
+                "workflow_automation/video_review.html",
+                {"run": run, "form": form, "preview_url": runner.review_image},
+            )
+
     if run.completed_at is None:
         if run_mode == "run_all":
             runner.run_all()
-            run.completed_at = timezone.now()
-            request.session.pop(f"run_{run_id}_index", None)
         else:
             if request.method == "POST" or step_index == 0:
                 runner.run_next()
@@ -767,6 +799,16 @@ def workflow_progress(request, run_id):
                 else:
                     request.session[f"run_{run_id}_index"] = step_index
                 request.session.modified = True
+
+        if runner.review_pending:
+            request.session[f"run_{run_id}_review"] = {
+                "index": runner.conversion_index,
+                "image": runner.review_image,
+                "file": runner.review_file,
+            }
+            request.session.modified = True
+        else:
+            request.session.pop(f"run_{run_id}_review", None)
 
         run.log = "\n".join(runner.logs)
         run.save()

--- a/equipment_booking_app/workflow_automation/workflow_runner.py
+++ b/equipment_booking_app/workflow_automation/workflow_runner.py
@@ -30,6 +30,12 @@ class WorkflowRunner:
         self.qa_video_review = qa_video_review
         self.logs = []
         self.current_step = 0
+        self.defer_current_step = False
+        self.review_pending = False
+        self.review_image = ""
+        self.review_file = ""
+        self.conversion_index = 0
+        self._last_step_index = None
 
         self.site_code = file_utils.parse_site_code(self.input_path)
         self.files = [
@@ -41,6 +47,8 @@ class WorkflowRunner:
     def run_all(self):
         while self.current_step < self.workflow.steps.count():
             self.run_next()
+            if self.defer_current_step or self.review_pending:
+                break
 
     def run_next(self):
         if self.current_step >= self.workflow.steps.count():
@@ -52,10 +60,19 @@ class WorkflowRunner:
             config = self.step_configs[self.current_step]
 
         method = getattr(self, f"run_{step.step_type}", self.run_default)
-        self.logs.append(f"Running step {step.order}: {step.get_step_type_display()}...")
+
+        if self._last_step_index != self.current_step:
+            self.logs.append(
+                f"Running step {step.order}: {step.get_step_type_display()}..."
+            )
+            self._last_step_index = self.current_step
+
+        self.defer_current_step = False
         result = method(config)
         self.logs.append(result)
-        self.current_step += 1
+        if not self.defer_current_step and not self.review_pending:
+            self.current_step += 1
+            self._last_step_index = None
         return True
 
     def run(self):
@@ -168,17 +185,44 @@ class WorkflowRunner:
         fmt = config.get("convert_format")
         if not fmt:
             return "Conversion skipped"
-        new_files = []
-        for f in self.files:
-            base = os.path.splitext(f)[0]
-            out = f"{base}.{fmt}"
-            file_utils.convert_video(f, out, fmt)
-            self.logs.append(f"Converted {os.path.basename(f)} to {fmt}")
-            if out != f:
-                os.remove(f)
-            new_files.append(out)
-        self.files = new_files
-        return "Conversion completed"
+
+        if not self.qa_video_review:
+            new_files = []
+            for f in self.files:
+                base = os.path.splitext(f)[0]
+                out = f"{base}.{fmt}"
+                file_utils.convert_video(f, out, fmt)
+                self.logs.append(f"Converted {os.path.basename(f)} to {fmt}")
+                if out != f:
+                    os.remove(f)
+                new_files.append(out)
+            self.files = new_files
+            return "Conversion completed"
+
+        if self.conversion_index >= len(self.files):
+            return "Conversion completed"
+
+        f = self.files[self.conversion_index]
+        base = os.path.splitext(f)[0]
+        out = f"{base}.{fmt}"
+        file_utils.convert_video(f, out, fmt)
+        self.logs.append(f"Converted {os.path.basename(f)} to {fmt}")
+        if out != f:
+            os.remove(f)
+        self.files[self.conversion_index] = out
+
+        preview_dir = os.path.join(self.output_path, "previews")
+        os.makedirs(preview_dir, exist_ok=True)
+        preview_name = os.path.basename(base) + "_preview.jpg"
+        preview_path = os.path.join(preview_dir, preview_name)
+        file_utils.generate_video_preview(out, preview_path)
+
+        self.review_pending = True
+        self.review_image = preview_path
+        self.review_file = out
+        self.conversion_index += 1
+        self.defer_current_step = True
+        return f"Review {os.path.basename(out)}"
 
     def run_pause_manual(self, config):
         return "Manual pause"


### PR DESCRIPTION
## Summary
- add `generate_video_preview` utility
- enable manual QA review after each conversion
- add `VideoReviewForm`
- create template `video_review.html`
- update workflow runner and views to pause for QA review

## Testing
- `python -m py_compile equipment_booking_app/workflow_automation/file_utils.py equipment_booking_app/workflow_automation/forms.py equipment_booking_app/workflow_automation/views.py equipment_booking_app/workflow_automation/workflow_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_687f5b4bf1a08325a2eb5e5706012625