### PR TITLE
Implement zone-based file renaming

### DIFF
--- a/equipment_booking_app/workflow_automation/file_utils.py
+++ b/equipment_booking_app/workflow_automation/file_utils.py
@@ -165,6 +165,52 @@ def organize_files(files, output_root, site_code="", target_folder=""):
     return paths
 
 
+def rename_with_zone(path: str, folder: str, zone_id: str) -> str:
+    """Rename ``path`` using ``zone_id`` and sequential zone numbering.
+
+    ``folder`` should be the destination directory containing any previously
+    named files. The zone prefix is derived from existing names in ``folder``
+    via :func:`generate_next_filename` and combined with ``zone_id``. The final
+    numeric suffix is automatically incremented based on existing files.
+    """
+
+    ext = os.path.splitext(path)[1]
+
+    candidate = generate_next_filename(folder, ext)
+    prefix = ""
+    if candidate:
+        zone_part = candidate.rsplit("-3V", 1)[0]
+        parts = zone_part.split("-")
+        if len(parts) > 2:
+            prefix = "-".join(parts[:-2])
+        else:
+            prefix = zone_part
+    if not prefix:
+        site_code = parse_site_code(folder)
+        parts = site_code.split("-")
+        if len(parts) > 2:
+            prefix = "-".join(parts[:-2])
+        else:
+            prefix = site_code
+
+    zone_prefix = f"{prefix}-{zone_id}"
+    pattern = re.compile(
+        rf"^{re.escape(zone_prefix)}-3V-(\d{{4}}){re.escape(ext)}$", re.IGNORECASE
+    )
+    max_idx = 0
+    for fname in os.listdir(folder):
+        m = pattern.match(fname)
+        if m:
+            idx = int(m.group(1))
+            if idx > max_idx:
+                max_idx = idx
+    new_idx = max_idx + 1
+    new_name = f"{zone_prefix}-3V-{new_idx:04d}{ext}"
+    new_path = os.path.join(folder, new_name)
+    os.rename(path, new_path)
+    return new_path
+
+
 def generate_next_filename(folder_path: str, extension: str = "") -> str | None:
     """Return the next sequential file name using existing zone patterns.
 

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -81,6 +81,22 @@ class GenerateNextFilenameTests(TestCase):
             self.assertEqual(name, "SL-SL-SR-011-A-3V-0002.mp4")
 
 
+class RenameWithZoneTests(TestCase):
+    def test_rename_with_zone(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            existing = os.path.join(tmp, "SL-SL-SR-101-A-3V-0001.mp4")
+            with open(existing, "wb") as fh:
+                fh.write(b"\x00")
+
+            sample = os.path.join(tmp, "sample.mp4")
+            with open(sample, "wb") as fh:
+                fh.write(b"\x00")
+
+            new_path = file_utils.rename_with_zone(sample, tmp, "101-A")
+            self.assertTrue(os.path.exists(new_path))
+            self.assertEqual(os.path.basename(new_path), "SL-SL-SR-101-A-3V-0002.mp4")
+
+
 class LogWriterTests(TestCase):
     def test_write_workflow_log(self):
         user = User.objects.create(username="loguser", first_name="Curtis", last_name="Hailes")

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -766,7 +766,19 @@ def workflow_progress(request, run_id):
         if request.method == "POST" and form.is_valid():
             zone = form.cleaned_data["zone_id"]
             flag = form.cleaned_data["flag_manual_edit"]
-            msg = f"Reviewed {os.path.basename(runner.review_file)} - Zone {zone}"
+            old_name = os.path.basename(runner.review_file)
+            new_path = file_utils.rename_with_zone(
+                runner.review_file, os.path.dirname(runner.review_file), zone
+            )
+            new_name = os.path.basename(new_path)
+            if new_name != old_name:
+                runner.logs.append(f"Renamed {old_name} -> {new_name}")
+            idx = runner.conversion_index - 1
+            if 0 <= idx < len(runner.files):
+                runner.files[idx] = new_path
+            runner.review_file = new_path
+
+            msg = f"Reviewed {new_name} - Zone {zone}"
             if flag:
                 msg += " (flagged for manual edit)"
             runner.logs.append(msg)


### PR DESCRIPTION
## Summary
- enable renaming with a zone id via `rename_with_zone`
- rename videos after manual review using the new helper
- test new rename logic

## Testing
- `pip install -r requirements.txt`
- `python manage.py test workflow_automation`

------
https://chatgpt.com/codex/tasks/task_e_687f5d26c00483258b7e80a4f3f22d49