### PR TITLE
Add video ordering step

### DIFF
--- a/equipment_booking_app/workflow_automation/forms.py
+++ b/equipment_booking_app/workflow_automation/forms.py
@@ -242,3 +242,17 @@ class VideoReviewForm(forms.Form):
     flag_manual_edit = forms.BooleanField(
         label="Flag for Manual Edit", required=False
     )
+
+
+class VideoOrderForm(forms.Form):
+    file_name = forms.CharField(widget=forms.HiddenInput())
+    zone_id = forms.CharField(
+        label="Zone ID",
+        max_length=50,
+        required=False,
+        widget=forms.TextInput(attrs={"placeholder": "e.g. 101-A"}),
+    )
+    order = forms.IntegerField(widget=forms.HiddenInput())
+
+
+VideoOrderFormSet = forms.formset_factory(VideoOrderForm, extra=0)

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
@@ -121,6 +121,21 @@
                 </div>
             {% endfor %}
         {% endif %}
+
+        {% if video_forms %}
+            <h4 class="mt-4">Video Order</h4>
+            <ul id="video-list" class="list-group mb-3">
+            {% for form in video_forms %}
+                <li class="list-group-item d-flex align-items-center" draggable="true">
+                    <span class="mr-2">&#x2630;</span>
+                    <span class="mr-3">{{ form.file_name.value }}</span>
+                    {{ form.file_name }}
+                    {{ form.order }}
+                    {{ form.zone_id }}
+                </li>
+            {% endfor %}
+            </ul>
+        {% endif %}
         <button type="submit" class="btn btn-primary mt-3">Run Workflow</button>
     </form>
 </div>
@@ -191,6 +206,31 @@ document.addEventListener('DOMContentLoaded', function(){
             }
         });
     });
+
+    const videoList = document.getElementById('video-list');
+    if (videoList) {
+        const updateOrder = () => {
+            videoList.querySelectorAll('li').forEach((li, idx) => {
+                li.querySelector('input[name$="-order"]').value = idx + 1;
+            });
+        };
+        let dragItem = null;
+        videoList.addEventListener('dragstart', e => {
+            dragItem = e.target.closest('li');
+        });
+        videoList.addEventListener('dragover', e => {
+            e.preventDefault();
+        });
+        videoList.addEventListener('drop', e => {
+            e.preventDefault();
+            const target = e.target.closest('li');
+            if (dragItem && target && dragItem !== target) {
+                videoList.insertBefore(dragItem, target);
+                updateOrder();
+            }
+        });
+        updateOrder();
+    }
 });
 </script>
 {% endblock %}

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -33,6 +33,7 @@ from .forms import (
     ConvertToolForm,
     ZipToolForm,
     VideoReviewForm,
+    VideoOrderFormSet,
 )
 
 from .workflow_runner import WorkflowRunner
@@ -548,6 +549,8 @@ def run_workflow(request):
     # Hold final logs if we end up running the workflow
     run = None
     final_logs = []
+    video_formset = None
+    video_files = []
 
     if request.method == "POST":
         # Final run is triggered when the hidden step fields are included in the
@@ -558,7 +561,8 @@ def run_workflow(request):
 
         if is_run_request:
             form = RunWorkflowForm(request.POST, user=request.user)
-            if form.is_valid():
+            video_formset = VideoOrderFormSet(request.POST, prefix="video")
+            if form.is_valid() and video_formset.is_valid():
                 workflow = form.cleaned_data["workflow"]
                 input_folder = form.cleaned_data["input_path"]
                 output_folder = form.cleaned_data["output_path"]
@@ -577,6 +581,14 @@ def run_workflow(request):
                         break
 
                 if len(step_forms) == workflow.steps.count():
+                    video_map = {}
+                    for vf in video_formset:
+                        if vf.cleaned_data.get("file_name"):
+                            video_map[vf.cleaned_data["file_name"]] = {
+                                "zone": vf.cleaned_data.get("zone_id", ""),
+                                "order": int(vf.cleaned_data.get("order", 0)),
+                            }
+
                     # Create DB record for the run
                     pause = form.cleaned_data.get("pause_between_steps", False)
                     run = WorkflowRun.objects.create(
@@ -594,6 +606,8 @@ def run_workflow(request):
                     if pause or workflow.qa_video_review:
                         request.session[f"run_{run.id}_configs"] = configs
                         request.session[f"run_{run.id}_index"] = 0
+                        if video_map:
+                            request.session[f"run_{run.id}_video_map"] = video_map
                         request.session.modified = True
                         return redirect("workflow_progress", run_id=run.id)
 
@@ -605,6 +619,7 @@ def run_workflow(request):
                         initials=run.initials,
                         step_configs=configs,
                         qa_video_review=workflow.qa_video_review,
+                        video_order_map=video_map,
                     )
 
                     # Execute steps sequentially and persist logs after each
@@ -711,6 +726,19 @@ def run_workflow(request):
         if request.session.get("proposed_name"):
             proposed_name = request.session["proposed_name"]
 
+    if not video_formset and input_folder and os.path.isdir(input_folder):
+        video_files = [
+            f
+            for f in os.listdir(input_folder)
+            if os.path.isfile(os.path.join(input_folder, f))
+            and file_utils.classify_media(os.path.join(input_folder, f))["is_video"]
+        ]
+        if len(video_files) > 1:
+            initial = [
+                {"file_name": f, "order": idx + 1}
+                for idx, f in enumerate(sorted(video_files))
+            ]
+            video_formset = VideoOrderFormSet(prefix="video", initial=initial)
     step_pairs = list(zip(workflow.steps.all(), StepFormSet)) if workflow else []
 
     return render(
@@ -721,6 +749,7 @@ def run_workflow(request):
             "step_forms": StepFormSet,
             "workflow": workflow,
             "step_pairs": step_pairs,
+            "video_forms": video_formset,
             "confirm": confirm,
             "input_folder": input_folder,
             "output_folder": output_folder,
@@ -741,6 +770,7 @@ def workflow_progress(request, run_id):
     run_mode = "pause" if run.pause_between_steps else "run_all"
 
     review_state = request.session.get(f"run_{run_id}_review")
+    video_map = request.session.get(f"run_{run_id}_video_map")
 
     runner = WorkflowRunner(
         run.workflow,
@@ -751,6 +781,7 @@ def workflow_progress(request, run_id):
         step_configs=configs,
         run_mode=run_mode,
         qa_video_review=run.workflow.qa_video_review,
+        video_order_map=video_map,
     )
     runner.current_step = step_index
     runner.logs = run.log.splitlines() if run.log else []
@@ -826,6 +857,7 @@ def workflow_progress(request, run_id):
         run.save()
         if run.completed_at is not None:
             write_workflow_log(run, runner.logs)
+            request.session.pop(f"run_{run_id}_video_map", None)
 
     done = run.completed_at is not None
 

--- a/equipment_booking_app/workflow_automation/workflow_runner.py
+++ b/equipment_booking_app/workflow_automation/workflow_runner.py
@@ -19,6 +19,7 @@ class WorkflowRunner:
         step_configs=None,
         run_mode="run_all",
         qa_video_review=False,
+        video_order_map=None,
     ):
         self.workflow = workflow
         self.input_path = input_path
@@ -28,6 +29,7 @@ class WorkflowRunner:
         self.step_configs = step_configs or []
         self.run_mode = run_mode
         self.qa_video_review = qa_video_review
+        self.video_order_map = video_order_map or {}
         self.logs = []
         self.current_step = 0
         self.defer_current_step = False
@@ -43,6 +45,10 @@ class WorkflowRunner:
             for f in os.listdir(self.input_path)
             if os.path.isfile(os.path.join(self.input_path, f))
         ]
+        if self.video_order_map:
+            self.files.sort(
+                key=lambda p: self.video_order_map.get(os.path.basename(p), {}).get("order", 0)
+            )
 
     def run_all(self):
         while self.current_step < self.workflow.steps.count():
@@ -186,15 +192,29 @@ class WorkflowRunner:
         if not fmt:
             return "Conversion skipped"
 
+        def _convert_file(path):
+            base = os.path.splitext(path)[0]
+            out = f"{base}.{fmt}"
+            file_utils.convert_video(path, out, fmt)
+            self.logs.append(f"Converted {os.path.basename(path)} to {fmt}")
+            if out != path:
+                os.remove(path)
+            return out
+
         if not self.qa_video_review:
             new_files = []
             for f in self.files:
-                base = os.path.splitext(f)[0]
-                out = f"{base}.{fmt}"
-                file_utils.convert_video(f, out, fmt)
-                self.logs.append(f"Converted {os.path.basename(f)} to {fmt}")
-                if out != f:
-                    os.remove(f)
+                out = _convert_file(f)
+                mapping = self.video_order_map.get(os.path.basename(f))
+                if mapping and mapping.get("zone"):
+                    renamed = file_utils.rename_with_zone(
+                        out, os.path.dirname(out), mapping["zone"]
+                    )
+                    if renamed != out:
+                        self.logs.append(
+                            f"Renamed {os.path.basename(out)} -> {os.path.basename(renamed)}"
+                        )
+                    out = renamed
                 new_files.append(out)
             self.files = new_files
             return "Conversion completed"
@@ -203,13 +223,22 @@ class WorkflowRunner:
             return "Conversion completed"
 
         f = self.files[self.conversion_index]
-        base = os.path.splitext(f)[0]
-        out = f"{base}.{fmt}"
-        file_utils.convert_video(f, out, fmt)
-        self.logs.append(f"Converted {os.path.basename(f)} to {fmt}")
-        if out != f:
-            os.remove(f)
+        out = _convert_file(f)
         self.files[self.conversion_index] = out
+        base = os.path.splitext(out)[0]
+
+        mapping = self.video_order_map.get(os.path.basename(f))
+        if mapping and mapping.get("zone"):
+            renamed = file_utils.rename_with_zone(
+                out, os.path.dirname(out), mapping["zone"]
+            )
+            if renamed != out:
+                self.logs.append(
+                    f"Renamed {os.path.basename(out)} -> {os.path.basename(renamed)}"
+                )
+            self.files[self.conversion_index] = renamed
+            self.conversion_index += 1
+            return "Conversion completed"
 
         preview_dir = os.path.join(self.output_path, "previews")
         os.makedirs(preview_dir, exist_ok=True)


### PR DESCRIPTION
## Summary
- enable mapping video files to zone IDs before running
- sort input videos by user-defined order
- auto-rename videos using this mapping to skip QA prompts
- add drag-and-drop UI for ordering videos

## Testing
- `python -m py_compile workflow_automation/forms.py workflow_automation/views.py workflow_automation/workflow_runner.py`
- `pip install -r requirements.txt`
- `python manage.py test workflow_automation.tests -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687f6046a9748325923b8826938fd640