### PR TITLE
Enable crop + audio removal during video conversion

### DIFF
--- a/automation_core/utils/video_converter.py
+++ b/automation_core/utils/video_converter.py
@@ -13,6 +13,7 @@ class ConvertFile(Task):
         insta360_types = [".insv", ".insp", ".lrv"]
         gopro_types = [".360"]
         source_extension = os.path.splitext(job["media_file"])[1].lower()
+        job.setdefault("original_media", job["media_file"])
 
         try:
             if source_extension in insta360_types:
@@ -26,8 +27,11 @@ class ConvertFile(Task):
             else:
                 job[self.name]["message"] = "File does not require conversion."
 
-            if any(
-                key in job for key in ["crop_start", "crop_end", "remove_audio"]
+            if (
+                source_extension not in gopro_types
+                and any(
+                    key in job for key in ["crop_start", "crop_end", "remove_audio"]
+                )
             ):
                 apply_options(job)
 
@@ -99,6 +103,7 @@ def apply_options(job):
         crop_start=start,
         crop_end=end,
         remove_audio=remove_audio,
+        original_media=job.get("original_media", src),
     )
     os.replace(tmp, src)
     return job

--- a/equipment_booking_app/utils/converter.py
+++ b/equipment_booking_app/utils/converter.py
@@ -25,6 +25,7 @@ def convert_directory(
             crop_start=crop_start,
             crop_end=crop_end,
             remove_audio=remove_audio,
+            original_media=src,
         )
         if dst != src:
             try:

--- a/equipment_booking_app/workflow_automation/file_utils.py
+++ b/equipment_booking_app/workflow_automation/file_utils.py
@@ -5,6 +5,7 @@ import subprocess
 from datetime import datetime
 
 
+
 def ffmpeg_exists():
     return shutil.which("ffmpeg") is not None
 
@@ -26,6 +27,29 @@ def extract_timestamp(filename: str) -> str:
     return mtime.strftime("%Y%m%d")
 
 
+def get_video_duration(path: str) -> float:
+    """Return the duration of a video in seconds using ffprobe."""
+    if not ffmpeg_exists():
+        return 0.0
+    try:
+        output = subprocess.check_output(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                path,
+            ],
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+        return float(output)
+    except (subprocess.CalledProcessError, ValueError, FileNotFoundError):
+        return 0.0
+
+
 def convert_video(
     src: str,
     dst: str,
@@ -34,6 +58,7 @@ def convert_video(
     crop_start: float = 0,
     crop_end: float = 0,
     remove_audio: bool = False,
+    original_media: str | None = None,
 ) -> str:
     """Convert a video using ffmpeg if available, else copy and rename.
 
@@ -41,12 +66,14 @@ def convert_video(
     """
     if ffmpeg_exists():
         cmd = ["ffmpeg", "-y", "-i", src]
-        if crop_start:
+        if crop_start > 0:
             cmd.extend(["-ss", str(crop_start)])
-        if crop_end:
-            cmd.extend(["-to", f"-{crop_end}"])
+        if crop_end > 0:
+            dur = get_video_duration(original_media or src)
+            trim = max(dur - (crop_start + crop_end), 0)
+            cmd.extend(["-t", str(trim)])
         if remove_audio:
-            cmd.extend(["-an"])
+            cmd.append("-an")
         cmd.append(dst)
         subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     else:


### PR DESCRIPTION
## Summary
- compute video duration via `ffprobe`
- trim and mute videos when converting
- pass original path for duration checks
- skip option handling for GoPro 360 scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f685f7a048325b7c8602bca1df93b