### PR TITLE
Implement video crop validation and review summary

### DIFF
--- a/equipment_booking_app/workflow_automation/file_utils.py
+++ b/equipment_booking_app/workflow_automation/file_utils.py
@@ -64,13 +64,18 @@ def convert_video(
 
     Additional options allow trimming from the start/end and removing audio.
     """
+    if crop_start < 0 or crop_end < 0:
+        raise ValueError("Crop values must be positive")
+    duration = get_video_duration(original_media or src)
+    if duration > 0 and (crop_start + crop_end) > duration:
+        raise ValueError("Crop values exceed video length")
+
     if ffmpeg_exists():
         cmd = ["ffmpeg", "-y", "-i", src]
         if crop_start > 0:
             cmd.extend(["-ss", str(crop_start)])
         if crop_end > 0:
-            dur = get_video_duration(original_media or src)
-            trim = max(dur - (crop_start + crop_end), 0)
+            trim = max(duration - (crop_start + crop_end), 0)
             cmd.extend(["-t", str(trim)])
         if remove_audio:
             cmd.append("-an")

--- a/equipment_booking_app/workflow_automation/forms.py
+++ b/equipment_booking_app/workflow_automation/forms.py
@@ -236,6 +236,30 @@ class StepSettingsForm(forms.Form):
                 initial=False,
             )
 
+    def clean(self):
+        cleaned = super().clean()
+        if self.step_type == "convert_360_video":
+            if cleaned.get("crop_start_enabled"):
+                start = cleaned.get("crop_start_seconds") or 0
+                if start < 0:
+                    self.add_error("crop_start_seconds", "Must be positive")
+            else:
+                cleaned["crop_start_seconds"] = 0
+            if cleaned.get("crop_end_enabled"):
+                end = cleaned.get("crop_end_seconds") or 0
+                if end < 0:
+                    self.add_error("crop_end_seconds", "Must be positive")
+            else:
+                cleaned["crop_end_seconds"] = 0
+        elif self.step_type == "trim":
+            start = cleaned.get("start_seconds") or 0
+            end = cleaned.get("end_seconds") or 0
+            if start < 0:
+                self.add_error("start_seconds", "Must be positive")
+            if end < 0:
+                self.add_error("end_seconds", "Must be positive")
+        return cleaned
+
 
 StepSettingsFormSet = forms.formset_factory(StepSettingsForm, extra=0)
 

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/video_review.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/video_review.html
@@ -4,6 +4,10 @@
 <h2 class="text-center mb-4">Video QA Review</h2>
 <div class="w-75 mx-auto" style="color:#192d38;">
     <img src="{{ preview_url }}" class="img-fluid mb-3" alt="Video preview">
+    <p class="mb-2"><strong>Edit</strong><br>
+        Cropping: {{ crop_start }}s start, {{ crop_end }}s end<br>
+        Audio: {% if audio_removed %}Removed{% else %}Kept{% endif %}
+    </p>
     <form method="post">
         {% csrf_token %}
         <div class="form-group">

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -6,6 +6,7 @@ from .models import Workflow
 from . import file_utils, views
 from .log_writer import write_workflow_log
 from types import SimpleNamespace
+from unittest.mock import patch
 import os
 import tempfile
 
@@ -113,5 +114,30 @@ class LogWriterTests(TestCase):
                 content = fh.read()
             self.assertIn("Workflow Execution Log", content)
             self.assertIn("Renamed:  sample.mp4", content)
+
+
+class ConvertVideoValidationTests(TestCase):
+    def test_crop_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "in.mp4")
+            dst = os.path.join(tmp, "out.mp4")
+            with open(src, "wb") as fh:
+                fh.write(b"\x00")
+
+            with patch(
+                "workflow_automation.file_utils.get_video_duration",
+                return_value=5.0,
+            ), patch(
+                "workflow_automation.file_utils.ffmpeg_exists",
+                return_value=False,
+            ):
+                with self.assertRaises(ValueError):
+                    file_utils.convert_video(src, dst, "mp4", crop_start=-1)
+                with self.assertRaises(ValueError):
+                    file_utils.convert_video(src, dst, "mp4", crop_end=-1)
+                with self.assertRaises(ValueError):
+                    file_utils.convert_video(src, dst, "mp4", crop_start=3, crop_end=3)
+                file_utils.convert_video(src, dst, "mp4", crop_start=1, crop_end=1)
+                self.assertTrue(os.path.exists(dst))
 
 

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -859,7 +859,14 @@ def workflow_progress(request, run_id):
             return render(
                 request,
                 "workflow_automation/video_review.html",
-                {"run": run, "form": form, "preview_url": runner.review_image},
+                {
+                    "run": run,
+                    "form": form,
+                    "preview_url": runner.review_image,
+                    "crop_start": runner.last_crop_start,
+                    "crop_end": runner.last_crop_end,
+                    "audio_removed": runner.last_remove_audio,
+                },
             )
 
     if run.completed_at is None:

--- a/equipment_booking_app/workflow_automation/workflow_runner.py
+++ b/equipment_booking_app/workflow_automation/workflow_runner.py
@@ -37,6 +37,9 @@ class WorkflowRunner:
         self.review_image = ""
         self.review_file = ""
         self.conversion_index = 0
+        self.last_crop_start = 0.0
+        self.last_crop_end = 0.0
+        self.last_remove_audio = False
         self._last_step_index = None
 
         self.site_code = file_utils.parse_site_code(self.input_path)
@@ -199,6 +202,10 @@ class WorkflowRunner:
         if config.get("crop_end_enabled"):
             crop_end = float(config.get("crop_end_seconds") or 0)
         remove_audio = config.get("remove_audio", False)
+
+        self.last_crop_start = crop_start
+        self.last_crop_end = crop_end
+        self.last_remove_audio = remove_audio
 
         def _convert_file(path):
             base = os.path.splitext(path)[0]


### PR DESCRIPTION
## Summary
- validate crop values in `convert_video` and forms
- store crop info in `WorkflowRunner` for review display
- show crop/audio summary on the video review page
- test crop validation logic

## Testing
- `pip install -r requirements.txt`
- `python manage.py test workflow_automation -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687f69f5bd608325acb7a4ec2e583357