### PR TITLE
Improve rename UI visibility

### DIFF
--- a/equipment_booking_app/utils/rename.py
+++ b/equipment_booking_app/utils/rename.py
@@ -27,7 +27,13 @@ def rename_directory(path: str, pattern: str = ""):
     return renamed
 
 
-def run_rename(raw_data_folder: str, output_folder: str, user_initials: str, full_name: str):
+def run_rename(
+    raw_data_folder: str,
+    output_folder: str,
+    user_initials: str,
+    full_name: str,
+    rename_pattern: str = "",
+):
     """Rename media in ``raw_data_folder`` and move to ``output_folder``.
 
     The function validates the input folder contains files, performs a smart
@@ -45,7 +51,7 @@ def run_rename(raw_data_folder: str, output_folder: str, user_initials: str, ful
 
     os.makedirs(output_folder, exist_ok=True)
 
-    renamed = rename_directory(raw_data_folder)
+    renamed = rename_directory(raw_data_folder, rename_pattern)
     results = []
     for name in renamed:
         src = os.path.join(raw_data_folder, name)

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
@@ -24,17 +24,19 @@
             <span id="output_folder_label" class="ml-2"></span>
         </div>
 
-        <div class="form-group">
-            <label for="id_user_initials">Your Initials</label>
-            {{ form.user_initials }}
-        </div>
-        <div class="form-group">
-            <label for="id_full_name">Full Name</label>
-            {{ form.full_name }}
-        </div>
-        <div class="form-group">
-            <label for="id_rename_pattern">Rename Pattern</label>
-            {{ form.rename_pattern }}
+        <div id="additional-fields" style="display:none;">
+            <div class="form-group">
+                <label for="id_user_initials">Your Initials</label>
+                {{ form.user_initials }}
+            </div>
+            <div class="form-group">
+                <label for="id_full_name">Full Name</label>
+                {{ form.full_name }}
+            </div>
+            <div class="form-group">
+                <label for="id_rename_pattern">Rename Pattern</label>
+                {{ form.rename_pattern }}
+            </div>
         </div>
         <button type="submit" class="btn btn-primary">Run Rename</button>
     </form>
@@ -54,6 +56,36 @@ document.addEventListener('DOMContentLoaded', function(){
     document.getElementById('raw_folder_btn').addEventListener('click', function(){
         rawPicker.click();
     });
+
+    const outputPicker = document.getElementById('output_folder_picker');
+    document.getElementById('output_folder_btn').addEventListener('click', function(){
+        outputPicker.click();
+    });
+    function checkVisibility(){
+        const raw = document.getElementById('id_raw_data_folder').value;
+        const out = document.getElementById('id_output_folder').value;
+        const fields = document.getElementById('additional-fields');
+        if(raw && out){
+            fields.style.display = 'block';
+        }
+    }
+
+    outputPicker.addEventListener('change', function(){
+        if (this.files.length){
+            const file = this.files[0];
+            const path = file.path || file.webkitRelativePath.split('/')[0];
+            document.getElementById('id_output_folder').value = path;
+            document.getElementById('output_folder_label').textContent = path;
+            const base = path.replace(/[\\/]+$/, '').split(/[\\/]/).pop();
+            const suggestion = `${base}-3V-{timestamp}{ext}`;
+            const renameField = document.getElementById('id_rename_pattern');
+            if(renameField && !renameField.value){
+                renameField.value = suggestion;
+            }
+        }
+        checkVisibility();
+    });
+
     rawPicker.addEventListener('change', function(){
         if (this.files.length){
             const file = this.files[0];
@@ -61,19 +93,8 @@ document.addEventListener('DOMContentLoaded', function(){
             document.getElementById('id_raw_data_folder').value = path;
             document.getElementById('raw_folder_label').textContent = path;
         }
+        checkVisibility();
     });
-
-    const outputPicker = document.getElementById('output_folder_picker');
-    document.getElementById('output_folder_btn').addEventListener('click', function(){
-        outputPicker.click();
-    });
-    outputPicker.addEventListener('change', function(){
-        if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
-            document.getElementById('id_output_folder').value = path;
-            document.getElementById('output_folder_label').textContent = path;
-        }
-    });
+    checkVisibility();
 });
 </script>

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -953,13 +953,14 @@ def run_rename_view(request):
         output_folder = form.cleaned_data["output_folder"]
         initials = form.cleaned_data["user_initials"]
         full_name = form.cleaned_data["full_name"]
+        pattern = form.cleaned_data.get("rename_pattern", "")
 
         if not os.path.isdir(raw_folder) or not any(
             os.path.isfile(os.path.join(raw_folder, f)) for f in os.listdir(raw_folder)
         ):
             form.add_error("raw_data_folder", "Selected folder has no valid files")
         else:
-            files = rename.run_rename(raw_folder, output_folder, initials, full_name)
+            files = rename.run_rename(raw_folder, output_folder, initials, full_name, pattern)
             messages.success(request, "Rename completed")
             selected_folder = raw_folder
 


### PR DESCRIPTION
## Summary
- show advanced rename fields only after folders are selected
- suggest a rename pattern based on the chosen output folder
- allow `run_rename` utility to accept an explicit rename pattern

## Testing
- `pip install -r requirements.txt`
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68833d61c76483258f35d176377b143b