### PR TITLE
Add building filter for zone naming

### DIFF
--- a/equipment_booking_app/workflow_automation/file_utils.py
+++ b/equipment_booking_app/workflow_automation/file_utils.py
@@ -260,7 +260,11 @@ def rename_with_zone(path: str, folder: str, zone_id: str, *, use_date_suffix: b
 
 
 def generate_next_filename(
-    folder_path: str, extension: str = "", *, use_date_suffix: bool = False
+    folder_path: str,
+    extension: str = "",
+    *,
+    building_name: str | None = None,
+    use_date_suffix: bool = False
 ) -> str | None:
     """Return the next sequential file name using existing zone patterns.
 
@@ -268,9 +272,13 @@ def generate_next_filename(
     directories (including all subfolders) for files matching the typical zone
     naming convention ``PREFIX-3V-XXXX.ext``. The highest numeric suffix found
     is incremented and combined with the detected prefix. ``extension`` is
-    appended to the returned name. If no matching files are found, ``None`` is
-    returned.
+    appended to the returned name. When ``building_name`` is provided, only
+    prefixes containing the normalized building token are considered. If no
+    matching files are found, ``None`` is returned.
     """
+
+    def _normalize(text: str) -> str:
+        return re.sub(r"[-\s]+", "-", text.strip().lower())
 
     search_roots = [os.path.abspath(folder_path)]
     parent = os.path.dirname(search_roots[0])
@@ -282,6 +290,7 @@ def generate_next_filename(
 
     pattern = re.compile(r"^([A-Za-z0-9-]+-3V)-(\d{4})", re.IGNORECASE)
     prefix_map = {}
+    building_token = _normalize(building_name) if building_name else None
 
     for root in search_roots:
         if not os.path.isdir(root):
@@ -291,6 +300,8 @@ def generate_next_filename(
                 match = pattern.match(fname)
                 if match:
                     prefix, idx = match.group(1), int(match.group(2))
+                    if building_token and building_token not in _normalize(prefix):
+                        continue
                     if idx > prefix_map.get(prefix, -1):
                         prefix_map[prefix] = idx
 

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -1,3 +1,10 @@
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "reality_capture_portal.settings")
+import django
+django.setup()
+from django.conf import settings
+settings.ALLOWED_HOSTS.append("testserver")
+
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.contrib.messages import get_messages
@@ -95,6 +102,25 @@ class GenerateNextFilenameTests(TestCase):
             )
             stamp = datetime.now().strftime("%d%m%y")
             self.assertEqual(name, f"SL-SL-SR-011-A-3V-{stamp}.mp4") if name else None
+
+    def test_generate_next_filename_building_filter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "sub"), exist_ok=True)
+            names = [
+                "SL-SL-SR-011-A-3V-0001.mp4",
+                "SL-SL-SR-011-A-3V-0002.mp4",
+                "SL-SL-AA-100-A-3V-0005.mp4",
+            ]
+            for n in names:
+                with open(os.path.join(tmp, "sub", n), "wb") as fh:
+                    fh.write(b"\x00")
+
+            name = file_utils.generate_next_filename(
+                os.path.join(tmp, "sub"),
+                ".mp4",
+                building_name="SR",
+            )
+            self.assertEqual(name, "SL-SL-SR-011-A-3V-0003.mp4")
 
 
 class RenameWithZoneTests(TestCase):

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -750,6 +750,7 @@ def run_workflow(request, workflow_id=None):
                 proposed_name = file_utils.generate_next_filename(
                     output_folder,
                     ext,
+                    building_name=file_utils.parse_site_code(output_folder),
                     use_date_suffix=workflow.use_date_suffix,
                 )
                 if proposed_name:


### PR DESCRIPTION
## Summary
- enhance file name generation with optional building filter
- store test settings for Django
- look up building name when suggesting new output file names
- add tests for building filter

## Testing
- `DJANGO_SETTINGS_MODULE=reality_capture_portal.settings pytest equipment_booking_app/workflow_automation/tests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68833de4923c8325ba9b78e85c78a601