### PR TITLE
Persist workflow run data in admin

### DIFF
--- a/equipment_booking_app/workflow_automation/admin.py
+++ b/equipment_booking_app/workflow_automation/admin.py
@@ -1,7 +1,16 @@
 from django.contrib import admin
 from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
-from .models import Equipment, Booking, Profile, LoginAttempt, UnknownLoginAttempt, Workflow, WorkflowStep
+from .models import (
+    Equipment,
+    Booking,
+    Profile,
+    LoginAttempt,
+    UnknownLoginAttempt,
+    Workflow,
+    WorkflowStep,
+    WorkflowRun,
+)
 
 # Admin interface for Equipment model
 class EquipmentAdmin(admin.ModelAdmin):
@@ -24,6 +33,37 @@ class ProfileInline(admin.StackedInline):
 class UserAdmin(BaseUserAdmin):
     inlines = (ProfileInline,)
 
+
+class WorkflowAdmin(admin.ModelAdmin):
+    list_display = (
+        "name",
+        "created_by",
+        "created_at",
+        "is_published",
+        "from_shared",
+    )
+    list_filter = ("is_published", "from_shared", "created_at")
+    search_fields = ("name", "description", "created_by__username")
+
+
+class WorkflowStepAdmin(admin.ModelAdmin):
+    list_display = ("workflow", "step_type", "order")
+    list_filter = ("workflow", "step_type")
+    search_fields = ("workflow__name",)
+
+
+class WorkflowRunAdmin(admin.ModelAdmin):
+    list_display = (
+        "workflow",
+        "user",
+        "started_at",
+        "completed_at",
+        "initials",
+        "project_code",
+    )
+    list_filter = ("workflow", "user", "started_at", "completed_at")
+    search_fields = ("workflow__name", "user__username", "project_code", "initials")
+
 # Unregister the default User admin and register the custom one
 admin.site.unregister(User)
 admin.site.register(User, UserAdmin)
@@ -32,5 +72,6 @@ admin.site.register(Booking, BookingAdmin)
 admin.site.register(Profile)
 admin.site.register(LoginAttempt)
 admin.site.register(UnknownLoginAttempt)
-admin.site.register(Workflow)
-admin.site.register(WorkflowStep)
+admin.site.register(Workflow, WorkflowAdmin)
+admin.site.register(WorkflowStep, WorkflowStepAdmin)
+admin.site.register(WorkflowRun, WorkflowRunAdmin)


### PR DESCRIPTION
## Summary
- expose WorkflowRun model in admin panel
- add helpful admin displays for Workflow, WorkflowStep, and WorkflowRun

## Testing
- `python equipment_booking_app/manage.py test workflow_automation`
- `python equipment_booking_app/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68836ce347888325a399da429b0ea249