### PR TITLE
Center content and add header style

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -1,5 +1,5 @@
 :root {
-  --bg-color: #101e29;
+  --bg-color: #BEDAE5;
   --text-color: #f1f1f1;
   --accent-start: #05E560;
   --accent-end: #B9FF00;
@@ -18,7 +18,7 @@ body {
 }
 
 body.light-mode {
-  --bg-color: #f4f4f4;
+  --bg-color: #BEDAE5;
   --text-color: #222;
   --input-bg: #fff;
   --input-border: #ced4da;
@@ -26,6 +26,10 @@ body.light-mode {
 
 main {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
 h1, h2 {
@@ -127,6 +131,12 @@ select:focus {
 
 body.sidebar-collapsed #main-content {
   margin-left: 60px;
+}
+
+.thin-header {
+  width: 100%;
+  height: 10px;
+  background-color: #192d38;
 }
 
 @media (max-width: 768px) {

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -128,6 +128,7 @@
 <body class="d-flex flex-column min-vh-100 dark-mode">
     {% include 'workflow_automation/partials/sidebar.html' %}
     <div id="main-content" class="flex-grow-1">
+    <header class="thin-header"></header>
 
     {% if messages %}
     <div class="container mt-3 mb-4">
@@ -139,7 +140,7 @@
     </div>
     {% endif %}
 
-    <main class="container flex-grow-1">
+    <main class="container flex-grow-1 d-flex flex-column align-items-center">
         {% block content %}
         {% endblock %}
 


### PR DESCRIPTION
## Summary
- apply new light grey color to app background
- add `.thin-header` styling and place header in layout
- center the main body content on every page

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68836e67d034832589c03c693433dd86