### PR TITLE
Add sticky zip progress bar

### DIFF
--- a/equipment_booking_app/utils/progress.py
+++ b/equipment_booking_app/utils/progress.py
@@ -1,0 +1,53 @@
+import threading
+
+_lock = threading.Lock()
+_data = {
+    "task": None,
+    "input_path": "",
+    "output_path": "",
+    "total": 0,
+    "completed": [],
+    "pending": [],
+    "percent": 0,
+    "status": "idle",
+}
+_args = ("","")
+
+def start(task: str, input_path: str, output_path: str, files: list[str]):
+    global _data, _args
+    with _lock:
+        _args = (input_path, output_path)
+        _data = {
+            "task": task,
+            "input_path": input_path,
+            "output_path": output_path,
+            "total": len(files),
+            "completed": [],
+            "pending": list(files),
+            "percent": 0,
+            "status": "running",
+        }
+
+def get():
+    with _lock:
+        return dict(_data)
+
+def update(file_name: str):
+    with _lock:
+        if file_name in _data["pending"]:
+            _data["pending"].remove(file_name)
+            _data["completed"].append(file_name)
+        if _data["total"]:
+            _data["percent"] = int(len(_data["completed"]) / _data["total"] * 100)
+
+def set_status(status: str):
+    with _lock:
+        _data["status"] = status
+
+def args():
+    with _lock:
+        return _args
+
+def reset():
+    start(None, "", "", [])
+    set_status("idle")

--- a/equipment_booking_app/utils/zip_task.py
+++ b/equipment_booking_app/utils/zip_task.py
@@ -1,0 +1,40 @@
+import os
+import threading
+import time
+from . import zipper, progress
+
+
+def _worker(input_path: str, output_folder: str):
+    rcp_pairs = []
+    for name in os.listdir(input_path):
+        if not name.lower().endswith('.rcp'):
+            continue
+        base = os.path.splitext(name)[0]
+        candidates = [f"{base}_support", f"{base} support"]
+        support = None
+        for cand in candidates:
+            cand_path = os.path.join(input_path, cand)
+            if os.path.isdir(cand_path):
+                support = cand_path
+                break
+        if support:
+            rcp_pairs.append((name, support))
+    file_names = [name for name, _ in rcp_pairs]
+    progress.start("Zipping RCP Files", input_path, output_folder, file_names)
+    for name, support in rcp_pairs:
+        while progress.get().get('status') == 'paused':
+            time.sleep(0.5)
+        if progress.get().get('status') in {'cancel', 'cancelled'}:
+            progress.set_status('cancelled')
+            return
+        rcp_path = os.path.join(input_path, name)
+        out_zip = os.path.join(output_folder, os.path.splitext(name)[0] + '.zip')
+        zipper.zip_directory(rcp_path, out_zip, support_folder=support)
+        progress.update(name)
+    progress.set_status('done')
+
+
+def start_zip(input_path: str, output_folder: str):
+    thread = threading.Thread(target=_worker, args=(input_path, output_folder), daemon=True)
+    thread.start()
+    return thread

--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -139,6 +139,23 @@ body.sidebar-collapsed #main-content {
   background-color: #192d38;
 }
 
+#zip-progress-container {
+  background-color: #192d38;
+  color: var(--text-color);
+  padding: 0.5rem 1rem;
+  z-index: 1100;
+}
+
+#zip-progress-container .progress {
+  height: 20px;
+  background-color: #6c757d;
+}
+
+#zip-progress-container .progress-bar {
+  background-image: linear-gradient(to right, var(--accent-start), var(--accent-end));
+  color: #192d38;
+}
+
 @media (max-width: 768px) {
   #sidebar {
     width: 100%;

--- a/equipment_booking_app/workflow_automation/static/js/progress.js
+++ b/equipment_booking_app/workflow_automation/static/js/progress.js
@@ -1,0 +1,72 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const container = document.getElementById('zip-progress-container');
+  if (!container) return;
+  const bar = document.getElementById('zip-progress-bar');
+  const percent = document.getElementById('zip-progress-percent');
+  const taskName = document.getElementById('zip-task-name');
+  const inputEl = document.getElementById('zip-input-path');
+  const outputEl = document.getElementById('zip-output-path');
+  const doneList = document.getElementById('zip-files-completed');
+  const pendingList = document.getElementById('zip-files-pending');
+
+  function getCookie(name) {
+    let cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+      const cookies = document.cookie.split(';');
+      for (let i = 0; i < cookies.length; i++) {
+        const cookie = cookies[i].trim();
+        if (cookie.substring(0, name.length + 1) === (name + '=')) {
+          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+          break;
+        }
+      }
+    }
+    return cookieValue;
+  }
+  const csrftoken = getCookie('csrftoken');
+
+  function sendAction(action) {
+    fetch('/progress-control/', {
+      method: 'POST',
+      headers: {'X-CSRFToken': csrftoken},
+      body: new URLSearchParams({action})
+    });
+  }
+
+  document.getElementById('pause-btn').addEventListener('click', () => sendAction('pause'));
+  document.getElementById('resume-btn').addEventListener('click', () => sendAction('resume'));
+  document.getElementById('cancel-btn').addEventListener('click', () => sendAction('cancel'));
+  document.getElementById('restart-btn').addEventListener('click', () => sendAction('restart'));
+
+  function update() {
+    fetch('/progress-status/')
+      .then(r => r.json())
+      .then(data => {
+        if (data.status && data.status !== 'idle') {
+          container.style.display = 'block';
+          taskName.textContent = data.task || 'Zipping RCP Files';
+          bar.style.width = data.percent + '%';
+          percent.textContent = data.percent + '%';
+          inputEl.textContent = data.input_path || '';
+          outputEl.textContent = data.output_path || '';
+          doneList.innerHTML = '';
+          data.completed.forEach(f => {
+            const li = document.createElement('li');
+            li.textContent = f;
+            doneList.appendChild(li);
+          });
+          pendingList.innerHTML = '';
+          data.pending.forEach(f => {
+            const li = document.createElement('li');
+            li.textContent = f;
+            pendingList.appendChild(li);
+          });
+        } else {
+          container.style.display = 'none';
+        }
+      });
+  }
+
+  update();
+  setInterval(update, 3000);
+});

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -129,6 +129,36 @@
     {% include 'workflow_automation/partials/sidebar.html' %}
     <div id="main-content" class="flex-grow-1">
     <header class="thin-header"></header>
+    <div id="zip-progress-container" class="fixed-top" style="display:none;">
+        <div class="d-flex justify-content-between align-items-center">
+            <span id="zip-task-name">Zipping RCP Files</span>
+            <div class="progress flex-grow-1 mx-3">
+                <div id="zip-progress-bar" class="progress-bar" role="progressbar" style="width:0%"></div>
+            </div>
+            <span id="zip-progress-percent">0%</span>
+            <button class="btn btn-link text-light p-0 ml-2" data-toggle="collapse" data-target="#zip-progress-detail" aria-expanded="false">Expand</button>
+        </div>
+        <div class="collapse" id="zip-progress-detail">
+            <div>Input: <span id="zip-input-path"></span></div>
+            <div>Output: <span id="zip-output-path"></span></div>
+            <div class="d-flex">
+                <div class="mr-3">
+                    <h6>Completed</h6>
+                    <ul id="zip-files-completed" class="list-unstyled mb-0"></ul>
+                </div>
+                <div>
+                    <h6>Pending</h6>
+                    <ul id="zip-files-pending" class="list-unstyled mb-0"></ul>
+                </div>
+            </div>
+            <div class="mt-2">
+                <button id="pause-btn" class="btn btn-secondary btn-sm">Pause</button>
+                <button id="resume-btn" class="btn btn-secondary btn-sm">Resume</button>
+                <button id="cancel-btn" class="btn btn-secondary btn-sm">Cancel</button>
+                <button id="restart-btn" class="btn btn-secondary btn-sm">Restart</button>
+            </div>
+        </div>
+    </div>
 
     {% if messages %}
     <div class="container mt-3 mb-4">
@@ -156,6 +186,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.2/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="{% static 'workflow_automation/js/theme-toggle.js' %}"></script>
+    <script src="{% static 'workflow_automation/js/progress.js' %}"></script>
 
     <script>
         function confirmLogout(event) {

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_zip.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_zip.html
@@ -23,10 +23,6 @@
         </div>
         <button type="submit" class="btn btn-primary">Run Zip</button>
     </form>
-    {% if zip_path %}
-    <h4 class="mt-4">Created Zip</h4>
-    <p>{{ zip_path }}</p>
-    {% endif %}
 </div>
 {% endblock %}
 

--- a/equipment_booking_app/workflow_automation/urls.py
+++ b/equipment_booking_app/workflow_automation/urls.py
@@ -31,4 +31,6 @@ urlpatterns = [
     path('run-rename/', views.run_rename_view, name='run_rename'),
     path('run-convert/', views.run_convert_view, name='run_convert'),
     path('run-zip/', views.run_zip_view, name='run_zip'),
+    path('progress-status/', views.progress_status, name='progress_status'),
+    path('progress-control/', views.progress_control, name='progress_control'),
 ]

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -39,7 +39,10 @@ from .forms import (
 )
 
 from .workflow_runner import WorkflowRunner
-from utils import rename, converter, zipper
+from utils import rename, converter, zipper, progress, zip_task
+from django.http import JsonResponse, HttpResponseBadRequest
+from django.views.decorators.http import require_POST
+import threading
 from . import file_utils
 from .log_writer import write_workflow_log
 
@@ -1057,34 +1060,36 @@ def run_zip_view(request):
         return redirect("accounts")
 
     form = ZipToolForm(request.POST or None)
-    zip_paths = []
     if request.method == "POST" and form.is_valid():
         input_path = form.cleaned_data["input_path"]
         output_folder = form.cleaned_data["output_zip"]
         os.makedirs(output_folder, exist_ok=True)
-        for name in os.listdir(input_path):
-            if not name.lower().endswith(".rcp"):
-                continue
-            rcp_path = os.path.join(input_path, name)
-            base = os.path.splitext(name)[0]
-            candidates = [f"{base}_support", f"{base} support"]
-            support_dir = None
-            for cand in candidates:
-                cand_path = os.path.join(input_path, cand)
-                if os.path.isdir(cand_path):
-                    support_dir = cand_path
-                    break
-            if not support_dir:
-                logger.warning("Support folder missing for %s", name)
-                continue
-            zip_file = os.path.join(output_folder, f"{base}.zip")
-            zipper.zip_directory(rcp_path, zip_file, support_folder=support_dir)
-            zip_paths.append(zip_file)
-        if zip_paths:
-            messages.success(request, "Zip completed")
-    return render(
-        request,
-        "workflow_automation/run_zip.html",
-        {"form": form, "zip_path": "\n".join(zip_paths) if zip_paths else None},
-    )
+        zip_task.start_zip(input_path, output_folder)
+        messages.info(request, "Zipping started")
+        return redirect("run_zip")
+    return render(request, "workflow_automation/run_zip.html", {"form": form})
+
+
+def progress_status(request):
+    """Return JSON status for the zip progress bar."""
+    return JsonResponse(progress.get())
+
+
+@require_POST
+def progress_control(request):
+    """Handle pause/resume/cancel/restart actions."""
+    action = request.POST.get("action")
+    if action == "pause":
+        progress.set_status("paused")
+    elif action == "resume":
+        progress.set_status("running")
+    elif action == "cancel":
+        progress.set_status("cancel")
+    elif action == "restart":
+        args = progress.args()
+        if all(args):
+            zip_task.start_zip(*args)
+    else:
+        return HttpResponseBadRequest("Invalid action")
+    return JsonResponse({"status": "ok"})
 


### PR DESCRIPTION
## Summary
- add progress tracking helpers and async zip task
- show a fixed progress bar in the base template
- poll progress via new endpoints and update using JS
- start background zipping when the zip form is submitted
- hook up progress controls for pause/resume/cancel/restart

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883876c4de883258ea9b7b77862137c