### PR TITLE
Add resumable progress tracking for zip tool

### DIFF
--- a/equipment_booking_app/utils/progress.py
+++ b/equipment_booking_app/utils/progress.py
@@ -10,22 +10,28 @@ _data = {
     "pending": [],
     "percent": 0,
     "status": "idle",
+    "current": "",
 }
 _args = ("","")
 
-def start(task: str, input_path: str, output_path: str, files: list[str]):
+def start(task: str, input_path: str, output_path: str, files: list[str], completed: list[str] | None = None):
     global _data, _args
     with _lock:
         _args = (input_path, output_path)
+        if completed is None:
+            completed = []
+        pending = [f for f in files if f not in completed]
+        percent = int(len(completed) / len(files) * 100) if files else 0
         _data = {
             "task": task,
             "input_path": input_path,
             "output_path": output_path,
             "total": len(files),
-            "completed": [],
-            "pending": list(files),
-            "percent": 0,
+            "completed": list(completed),
+            "pending": pending,
+            "percent": percent,
             "status": "running",
+            "current": "",
         }
 
 def get():
@@ -34,11 +40,16 @@ def get():
 
 def update(file_name: str):
     with _lock:
+        _data["current"] = ""
         if file_name in _data["pending"]:
             _data["pending"].remove(file_name)
             _data["completed"].append(file_name)
         if _data["total"]:
             _data["percent"] = int(len(_data["completed"]) / _data["total"] * 100)
+
+def set_current(file_name: str):
+    with _lock:
+        _data["current"] = file_name
 
 def set_status(status: str):
     with _lock:

--- a/equipment_booking_app/utils/zip_task.py
+++ b/equipment_booking_app/utils/zip_task.py
@@ -4,8 +4,8 @@ import time
 from . import zipper, progress
 
 
-def _worker(input_path: str, output_folder: str):
-    rcp_pairs = []
+def _collect_rcp_pairs(input_path: str):
+    pairs = []
     for name in os.listdir(input_path):
         if not name.lower().endswith('.rcp'):
             continue
@@ -18,23 +18,46 @@ def _worker(input_path: str, output_folder: str):
                 support = cand_path
                 break
         if support:
-            rcp_pairs.append((name, support))
-    file_names = [name for name, _ in rcp_pairs]
-    progress.start("Zipping RCP Files", input_path, output_folder, file_names)
+            pairs.append((name, support))
+    return pairs
+
+
+def _worker(rcp_pairs: list[tuple[str, str]], input_path: str, output_folder: str):
     for name, support in rcp_pairs:
-        while progress.get().get('status') == 'paused':
-            time.sleep(0.5)
-        if progress.get().get('status') in {'cancel', 'cancelled'}:
-            progress.set_status('cancelled')
-            return
+        if name in progress.get().get('completed', []):
+            continue
+        while True:
+            status = progress.get().get('status')
+            if status == 'paused':
+                time.sleep(0.5)
+                continue
+            if status in {'cancel', 'cancelled'}:
+                progress.set_status('cancelled')
+                return
+            break
+        progress.set_current(name)
         rcp_path = os.path.join(input_path, name)
         out_zip = os.path.join(output_folder, os.path.splitext(name)[0] + '.zip')
         zipper.zip_directory(rcp_path, out_zip, support_folder=support)
         progress.update(name)
+    progress.set_current("")
     progress.set_status('done')
 
 
-def start_zip(input_path: str, output_folder: str):
-    thread = threading.Thread(target=_worker, args=(input_path, output_folder), daemon=True)
+def start_zip(input_path: str, output_folder: str, completed: list[str] | None = None):
+    rcp_pairs = _collect_rcp_pairs(input_path)
+    file_names = [name for name, _ in rcp_pairs]
+
+    existing_zips = {os.path.splitext(n)[0] for n in os.listdir(output_folder) if n.lower().endswith('.zip')}
+    auto_completed = [name for name in file_names if os.path.splitext(name)[0] in existing_zips]
+    if completed:
+        for n in auto_completed:
+            if n not in completed:
+                completed.append(n)
+    else:
+        completed = auto_completed
+
+    progress.start("Zipping RCP Files", input_path, output_folder, file_names, completed)
+    thread = threading.Thread(target=_worker, args=(rcp_pairs, input_path, output_folder), daemon=True)
     thread.start()
     return thread

--- a/equipment_booking_app/workflow_automation/static/js/progress.js
+++ b/equipment_booking_app/workflow_automation/static/js/progress.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const outputEl = document.getElementById('zip-output-path');
   const doneList = document.getElementById('zip-files-completed');
   const pendingList = document.getElementById('zip-files-pending');
-
+  
   function getCookie(name) {
     let cookieValue = null;
     if (document.cookie && document.cookie !== '') {
@@ -49,14 +49,16 @@ document.addEventListener('DOMContentLoaded', function () {
           percent.textContent = data.percent + '%';
           inputEl.textContent = data.input_path || '';
           outputEl.textContent = data.output_path || '';
+
           doneList.innerHTML = '';
-          data.completed.forEach(f => {
+          (data.completed_files || []).forEach(f => {
             const li = document.createElement('li');
             li.textContent = f;
             doneList.appendChild(li);
           });
+
           pendingList.innerHTML = '';
-          data.pending.forEach(f => {
+          (data.pending_files || []).forEach(f => {
             const li = document.createElement('li');
             li.textContent = f;
             pendingList.appendChild(li);

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -1072,7 +1072,19 @@ def run_zip_view(request):
 
 def progress_status(request):
     """Return JSON status for the zip progress bar."""
-    return JsonResponse(progress.get())
+    data = progress.get()
+    return JsonResponse({
+        "task": data.get("task"),
+        "completed": len(data.get("completed", [])),
+        "total": data.get("total", 0),
+        "status": data.get("status"),
+        "percent": data.get("percent", 0),
+        "current_file": data.get("current", ""),
+        "input_path": data.get("input_path", ""),
+        "output_path": data.get("output_path", ""),
+        "completed_files": data.get("completed", []),
+        "pending_files": data.get("pending", []),
+    })
 
 
 @require_POST
@@ -1086,9 +1098,18 @@ def progress_control(request):
     elif action == "cancel":
         progress.set_status("cancel")
     elif action == "restart":
+        data = progress.get()
         args = progress.args()
         if all(args):
-            zip_task.start_zip(*args)
+            completed = data.get("completed", [])
+            if completed:
+                last = completed[-1]
+                last_zip = os.path.join(data.get("output_path", ""), os.path.splitext(last)[0] + ".zip")
+                if os.path.exists(last_zip):
+                    os.remove(last_zip)
+                completed = completed[:-1]
+            progress.set_status("cancel")
+            zip_task.start_zip(args[0], args[1], completed=completed)
     else:
         return HttpResponseBadRequest("Invalid action")
     return JsonResponse({"status": "ok"})


### PR DESCRIPTION
## Summary
- extend progress tracker with current file and support pre-completed projects
- update zip task to skip already zipped files and resume from pause/restart
- enhance progress status API and control logic
- adjust frontend script to consume new JSON format

## Testing
- `python -m py_compile equipment_booking_app/utils/progress.py equipment_booking_app/utils/zip_task.py equipment_booking_app/workflow_automation/views.py`
- `python manage.py test workflow_automation.tests -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688389996e5083259ef31fbdd44bdf51