### PR TITLE
Add central launcher and section dashboards

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
@@ -1,0 +1,6 @@
+{% extends 'workflow_automation/base.html' %}
+
+{% block content %}
+<h1 class="text-center mt-4" style="color: #BEDAE5;">Equipment Booking Dashboard</h1>
+<p class="text-center">This is a placeholder for the equipment booking dashboard.</p>
+{% endblock %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
@@ -1,0 +1,60 @@
+{% extends 'workflow_automation/base.html' %}
+{% load static %}
+
+{% block content %}
+<h1 class="text-center mt-4" style="color: #BEDAE5;">Welcome</h1>
+
+<div class="container mt-4">
+    {% if notice %}
+    <div class="card mb-4 mx-auto" style="color:#192d38;">
+        <div class="card-body">
+            <h5 class="card-title">Message Board</h5>
+            <p class="card-text">{{ notice.message }}</p>
+            {% if user.is_superuser %}
+            <form method="post" action="{% url 'remove_notice' %}" onsubmit="return confirm('Delete this notice?');">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-danger">Remove Notice</button>
+            </form>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if user.is_superuser %}
+    <div class="card mb-4 mx-auto" style="color:#192d38;">
+        <div class="card-body">
+            <h5 class="card-title">Create a Notice</h5>
+            <form method="post">
+                {% csrf_token %}
+                <div class="form-group">
+                    <label for="message">Notice Message:</label>
+                    <textarea name="message" id="message" rows="4" class="form-control" required></textarea>
+                </div>
+                <button type="submit" class="btn btn-primary mt-2">Create Notice</button>
+            </form>
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="row g-4 mt-2">
+        <div class="col-12 col-md-6 mb-4">
+            <a href="{% url 'home' %}" class="text-decoration-none">
+                <div class="card h-100 text-dark">
+                    <div class="card-body d-flex flex-column justify-content-center align-items-center">
+                        <h2 class="card-title">Automation Tools</h2>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-12 col-md-6 mb-4">
+            <a href="{% url 'equipment_dashboard' %}" class="text-decoration-none">
+                <div class="card h-100 text-dark">
+                    <div class="card-body d-flex flex-column justify-content-center align-items-center">
+                        <h2 class="card-title">Equipment Booking</h2>
+                    </div>
+                </div>
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/equipment_booking_app/workflow_automation/urls.py
+++ b/equipment_booking_app/workflow_automation/urls.py
@@ -2,7 +2,9 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.home, name='home'),
+    path('', views.launcher, name='launcher'),
+    path('automation/', views.home, name='home'),
+    path('equipment/', views.equipment_dashboard, name='equipment_dashboard'),
     path('signup/', views.signup, name='signup'),
     path('login/', views.login_view, name='login'),
     path('logout/', views.logout_view, name='logout'),

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -56,6 +56,21 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth import authenticate, login, logout
 
 
+def launcher(request):
+    """Render the root landing page with message board and section links."""
+    notice = Notice.objects.last()
+
+    if request.method == "POST" and request.user.is_superuser:
+        message = request.POST.get("message")
+        if message:
+            Notice.objects.create(message=message, created_by=request.user)
+            messages.success(request, "Notice created successfully!")
+            return redirect("launcher")
+
+    context = {"notice": notice}
+    return render(request, "workflow_automation/launcher.html", context)
+
+
 @login_required
 def home(request):
     """Render the dashboard-style home page."""
@@ -79,6 +94,12 @@ def home(request):
         "pending_count": pending_count,
     }
     return render(request, "workflow_automation/home.html", context)
+
+
+@login_required
+def equipment_dashboard(request):
+    """Placeholder dashboard for equipment booking."""
+    return render(request, "workflow_automation/equipment_dashboard.html")
 
 
 def signup(request):
@@ -376,7 +397,7 @@ def remove_notice(request):
     if request.method == 'POST':
         Notice.objects.all().delete()
         messages.success(request, 'Notice removed successfully.')
-    return redirect('home')
+    return redirect(request.META.get('HTTP_REFERER', 'home'))
 
 
 def security_notice(request):


### PR DESCRIPTION
## Summary
- Add root landing page with message board and links to Automation Tools and Equipment Booking
- Expose automation dashboard at `/automation/` and placeholder equipment booking dashboard at `/equipment/`
- Redirect notice removal back to the page that issued the request

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689092207fe883259b33c5614a6b68e2