### PR TITLE
feat: context-aware sidebar

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -109,6 +109,8 @@ select:focus {
   padding-top: 20px;
   z-index: 1000;
   color: white;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar.collapsed {
@@ -126,7 +128,13 @@ select:focus {
 
 .sidebar .nav-link {
   display: block;
-  margin: 10px;
+  margin: 0 10px;
+}
+
+.sidebar nav {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 body.sidebar-collapsed #main-content {

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -33,6 +33,8 @@
             overflow-x: hidden;
             padding-top: 20px;
             z-index: 1000;
+            display: flex;
+            flex-direction: column;
         }
 
         #sidebar.collapsed {
@@ -118,6 +120,17 @@
         .btn:hover {
             background-image: linear-gradient(to right, #B9FF00, #05E560);
             color: #192d38;
+        }
+
+        /* Sidebar spacing */
+        #sidebar nav {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        #sidebar nav a {
+            margin: 0 10px;
         }
     </style>
     

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
@@ -8,23 +8,24 @@
     </div>
     <nav class="flex-column mt-4">
         {% if user.is_authenticated %}
-            {% if user.is_superuser %}
-                <a href="{% url 'booking_list' %}" class="nav-link">All Bookings</a>
-            {% else %}
-                <a href="{% url 'my_bookings' %}" class="nav-link">My Bookings</a>
-            {% endif %}
-            <a href="{% url 'create_booking' %}" class="nav-link">Create Booking</a>
-            <a href="{% url 'my_workflows' %}" class="nav-link">My Workflows</a>
-            <a href="{% url 'shared_workflows' %}" class="nav-link">Shared Workflows</a>
-            <a href="{% url 'workflow_dashboard' %}" class="nav-link">Automation Workflows</a>
-            <a href="{% url 'accounts' %}" class="nav-link">View Account</a>
-            {% if not user.is_superuser %}
-                <a href="{% url 'contact' %}" class="nav-link">Contact</a>
-            {% endif %}
-            {% if user.is_superuser %}
-                <a href="{% url 'review_workflows' %}" class="nav-link">Review Workflows</a>
-                <a href="http://127.0.0.1:8000/admin-b4a939d29b7cda4b/" class="nav-link">Admin Controls</a>
-            {% endif %}
+            {% with path=request.path %}
+                {% if 'automation' in path or 'workflows' in path or 'run-' in path %}
+                    <a href="{% url 'my_workflows' %}" class="nav-link">My Workflows</a>
+                    <a href="{% url 'create_workflow' %}" class="nav-link">Create Workflow</a>
+                    <a href="{% url 'workflow_dashboard' %}" class="nav-link">Logs</a>
+                    {% if user.is_staff or user.is_superuser %}
+                        <a href="{% url 'review_workflows' %}" class="nav-link">Review Workflows</a>
+                        <a href="#" class="nav-link">Manage Templates</a>
+                    {% endif %}
+                {% elif 'equipment' in path or 'booking' in path or 'calendar' in path %}
+                    <a href="{% url 'create_booking' %}" class="nav-link">Book Equipment</a>
+                    <a href="{% url 'booking_list' %}" class="nav-link">View Calendar</a>
+                    {% if user.is_staff or user.is_superuser %}
+                        <a href="{% url 'booking_list' %}" class="nav-link">Admin Bookings</a>
+                        <a href="#" class="nav-link">Manage Inventory</a>
+                    {% endif %}
+                {% endif %}
+            {% endwith %}
         {% endif %}
     </nav>
     <div class="mt-auto mb-4">
@@ -35,5 +36,6 @@
             <a href="{% url 'logout' %}" id="logout-link" class="nav-link" onclick="confirmLogout(event)">Logout</a>
         {% endif %}
         <button id="themeToggle" class="btn btn-sm d-block mt-3">Toggle Theme</button>
+        <div class="text-center mt-3 small">Curtis Hailes, AtkinsRéalis 2025</div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- tailor sidebar links to automation vs equipment sections and show admin tools when applicable
- space out sidebar items and keep logout pinned to bottom
- add sidebar footer

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890937779d083259f2eb7286e807df2