### PR TITLE
Ensure original booking sidebar options remain accessible

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
@@ -26,6 +26,10 @@
                     {% endif %}
                 {% endif %}
             {% endwith %}
+            <a href="{% url 'accounts' %}" class="nav-link">Profile</a>
+            {% if user.is_superuser %}
+                <a href="{% url 'inbox' %}" class="nav-link">Inbox</a>
+            {% endif %}
         {% endif %}
     </nav>
     <div class="mt-auto mb-4">

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -342,3 +342,19 @@ class WorkflowReviewFlowTests(TestCase):
         self.assertFalse(self.wf.awaiting_review)
         self.assertEqual(self.wf.rejection_comment, "fix")
 
+
+class SidebarLinksTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="user1", password="pass")
+        self.admin = User.objects.create_user(username="admin1", password="pass", is_superuser=True)
+
+    def test_profile_link_visible(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("home"))
+        self.assertContains(response, reverse("accounts"))
+
+    def test_inbox_link_visible_for_superuser(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(reverse("home"))
+        self.assertContains(response, reverse("inbox"))
+


### PR DESCRIPTION
## Summary
- Restore profile and inbox links in sidebar so booking app options remain available
- Add regression tests covering new sidebar links

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68909b997304832586f091cc6d9d7b4d