### PR TITLE
Adjust sidebar widths and add favicon

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -103,13 +103,14 @@ select:focus {
 
 
 
+
 .sidebar {
   position: fixed;
   top: 0;
   left: 0;
   height: 100%;
   background-color: #192d38;
-  width: 250px;
+  width: 320px;
   transition: width 0.3s;
   overflow-x: hidden;
   padding-top: 20px;
@@ -120,7 +121,7 @@ select:focus {
 }
 
 .sidebar.collapsed {
-  width: 60px;
+  width: 110px;
 }
 
 .sidebar .toggle-btn {
@@ -144,7 +145,7 @@ select:focus {
 }
 
 body.sidebar-collapsed #main-content {
-  margin-left: 60px;
+  margin-left: 110px;
 }
 
 .thin-header {

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -5,11 +5,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}AtkinsRéalis Automation App{% endblock %}</title>
-    
+
     <!-- Bootstrap CSS CDN for responsive design and styling -->
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome for sidebar icons -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <link rel="icon" type="image/png" href="{% static 'images/Collapsed side bar Logo.png' %}">
 
     <!-- Custom font definitions for the app -->
     <style>
@@ -29,7 +30,7 @@
             left: 0;
             height: 100%;
             background-color: #192d38;
-            width: 250px;
+            width: 320px;
             transition: width 0.3s;
             overflow-x: hidden;
             padding-top: 20px;
@@ -39,7 +40,7 @@
         }
 
         #sidebar.collapsed {
-            width: 60px;
+            width: 110px;
         }
 
         #sidebar .toggle-btn {
@@ -50,12 +51,12 @@
         }
 
         #main-content {
-            margin-left: 250px;
+            margin-left: 320px;
             transition: margin-left 0.3s;
         }
 
         body.sidebar-collapsed #main-content {
-            margin-left: 60px;
+            margin-left: 110px;
         }
 
         /* Sidebar icon and label behaviour */


### PR DESCRIPTION
## Summary
- expand sidebar to 320px when open and 110px when collapsed so logos display fully
- add site favicon using collapsed sidebar logo

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68922d9921448325868224a6017850cb