### PR TITLE
Improve text contrast and personalised greeting

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -98,7 +98,7 @@ select:focus {
 
 .card {
   background-color: #1e2b38;
-  color: var(--text-color);
+  color: var(--bg-color);
 }
 
 

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
@@ -6,7 +6,7 @@
 
 <section class="mt-4">
     {% if user.is_authenticated %}
-        <h4 class="text-center mb-4">Welcome, {{ user.username }}!</h4>
+        <h4 class="text-center mb-4" style="color:#192d38;">Welcome {{ user.username }}</h4>
 
         <div class="container">
             <!-- Priority automation actions -->
@@ -42,7 +42,7 @@
         </div>
 
         {% if notice %}
-        <div class="card w-75 mb-3 mx-auto" style="color:#192d38;">
+        <div class="card w-75 mb-3 mx-auto">
             <div class="card-body">
                 <h5 class="card-title">Notice Board</h5>
                 <p class="card-text">{{ notice.message }}</p>
@@ -57,7 +57,7 @@
         {% endif %}
 
         {% if user.is_superuser %}
-        <div class="card w-75 mx-auto" style="color:#192d38;">
+        <div class="card w-75 mx-auto">
             <div class="card-body">
                 <h5 class="card-title">Create a Notice</h5>
                 <form method="post">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
@@ -2,11 +2,15 @@
 {% load static %}
 
 {% block content %}
-<h1 class="text-center mt-4" style="color: #BEDAE5;">Welcome</h1>
+{% if user.is_authenticated %}
+<h1 class="text-center mt-4" style="color: #192d38;">Welcome {{ user.username }}</h1>
+{% else %}
+<h1 class="text-center mt-4" style="color: #192d38;">Welcome</h1>
+{% endif %}
 
 <div class="container mt-4">
     {% if notice %}
-    <div class="card mb-4 mx-auto" style="color:#192d38;">
+    <div class="card mb-4 mx-auto">
         <div class="card-body">
             <h5 class="card-title">Message Board</h5>
             <p class="card-text">{{ notice.message }}</p>
@@ -21,7 +25,7 @@
     {% endif %}
 
     {% if user.is_superuser %}
-    <div class="card mb-4 mx-auto" style="color:#192d38;">
+    <div class="card mb-4 mx-auto">
         <div class="card-body">
             <h5 class="card-title">Create a Notice</h5>
             <form method="post">
@@ -39,7 +43,7 @@
     <div class="row g-4 mt-2">
         <div class="col-12 col-md-6 mb-4">
             <a href="{% url 'home' %}" class="text-decoration-none">
-                <div class="card h-100 text-dark">
+                <div class="card h-100">
                     <div class="card-body d-flex flex-column justify-content-center align-items-center">
                         <h2 class="card-title">Automation Tools</h2>
                     </div>
@@ -48,7 +52,7 @@
         </div>
         <div class="col-12 col-md-6 mb-4">
             <a href="{% url 'equipment_dashboard' %}" class="text-decoration-none">
-                <div class="card h-100 text-dark">
+                <div class="card h-100">
                     <div class="card-body d-flex flex-column justify-content-center align-items-center">
                         <h2 class="card-title">Equipment Booking</h2>
                     </div>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_convert.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_convert.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="text-center mb-4">Run Convert Tool</h2>
-<div class="card p-4 w-75 mx-auto mb-4" style="color:#192d38;">
+<div class="card p-4 w-75 mx-auto mb-4">
     <form method="post">
         {% csrf_token %}
         <div style="display:none;">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="text-center mb-4">Run Rename Tool</h2>
-<div class="card p-4 w-75 mx-auto mb-4" style="color:#192d38;">
+<div class="card p-4 w-75 mx-auto mb-4">
     <form method="post">
         {% csrf_token %}
         <div style="display:none;">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="text-center mb-4">Run Workflow</h2>
-<div class="card p-4 w-75 mx-auto mb-4" style="color:#192d38;">
+<div class="card p-4 w-75 mx-auto mb-4">
     {% if confirm %}
         <div class="alert alert-success">
             <strong>Input Folder:</strong> {{ input_folder }}<br>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_zip.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_zip.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="text-center mb-4">Run Zip Tool</h2>
-<div class="card p-4 w-75 mx-auto mb-4" style="color:#192d38;">
+<div class="card p-4 w-75 mx-auto mb-4">
     <form method="post">
         {% csrf_token %}
         <div style="display:none;">


### PR DESCRIPTION
## Summary
- make all cards use the site’s light blue text color for better contrast against dark backgrounds
- personalise the landing page with a navy “Welcome {username}” heading and ensure message board and navigation cards use readable light blue text
- show dashboard welcome message in navy and clean up notice board and creation forms to inherit the improved card color

## Testing
- `pip install -q -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689230fae0cc83259e48d449e7b39aeb