### PR TITLE
Remove sidebar credit and apply navy text color

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -26,11 +26,16 @@
 
 body {
   background-color: var(--bg-color);
-  color: var(--text-color);
+  color: #000080;
   font-family: 'Bienvenue', sans-serif;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+}
+
+a,
+a:visited {
+  color: #000080;
 }
 
 body.light-mode {

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
@@ -53,6 +53,5 @@
                 <span class="sidebar-label">Logout</span>
             </a>
         {% endif %}
-        <div class="text-center mt-3 small">Curtis Hailes, AtkinsRéalis 2025</div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- remove Curtis Hailes attribution from sidebar
- use navy for default text and links on light background

## Testing
- `python3 manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68923354d5e0832598858c19f9368d7d