### PR TITLE
Raise sidebar logout button with separators

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
@@ -37,7 +37,7 @@
             <hr>
         {% endif %}
     </nav>
-    <div class="mt-auto mb-4">
+    <div class="mt-auto mb-5">
         {% if not user.is_authenticated %}
             <a href="{% url 'login' %}" class="auth-btn d-block mb-2" title="Login" aria-label="Login">
                 <i class="fas fa-sign-in-alt"></i>
@@ -48,10 +48,12 @@
                 <span class="sidebar-label">Sign Up</span>
             </a>
         {% else %}
+            <hr>
             <a href="{% url 'logout' %}" id="logout-link" class="nav-link" onclick="confirmLogout(event)" title="Logout" aria-label="Logout">
                 <i class="fas fa-sign-out-alt"></i>
                 <span class="sidebar-label">Logout</span>
             </a>
+            <hr>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Move logout action slightly above the footer
- Separate logout with horizontal rules for visual clarity

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6892354ae6b08325bb8e5688cd6b4e39