### PR TITLE
Adjust sidebar logout spacing and add top separator

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -166,6 +166,10 @@ select:focus {
   gap: 10px;
 }
 
+.logout-container {
+  margin-bottom: 2.25rem;
+}
+
 body.sidebar-collapsed #main-content {
   margin-left: 110px;
 }

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
@@ -7,6 +7,7 @@
         </a>
     </div>
     <nav class="flex-column mt-4">
+        <hr>
         {% if user.is_authenticated %}
             <a href="{% url 'home' %}" class="nav-link" title="Automation Tools" aria-label="Automation Tools">
                 <i class="fas fa-robot"></i>
@@ -37,7 +38,7 @@
             <hr>
         {% endif %}
     </nav>
-    <div class="mt-auto mb-5">
+    <div class="mt-auto logout-container">
         {% if not user.is_authenticated %}
             <a href="{% url 'login' %}" class="auth-btn d-block mb-2" title="Login" aria-label="Login">
                 <i class="fas fa-sign-in-alt"></i>


### PR DESCRIPTION
## Summary
- Add a top separator line above the first sidebar option
- Fine-tune logout button spacing with custom CSS class

## Testing
- `pytest` *(no tests found)*
- `python equipment_booking_app/manage.py test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689236b017c083259788b6118daf6aa6