### PR TITLE
Replace navy text color with dark grey

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -26,7 +26,7 @@
 
 body {
   background-color: var(--bg-color);
-  color: #000080;
+  color: #192d38;
   font-family: 'Bienvenue', sans-serif;
   min-height: 100vh;
   display: flex;
@@ -35,7 +35,7 @@ body {
 
 a,
 a:visited {
-  color: #000080;
+  color: #192d38;
 }
 
 body.light-mode {

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
@@ -1,6 +1,6 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<h1 class="text-center mt-4" style="color: navy;">Equipment Booking Dashboard</h1>
+<h1 class="text-center mt-4" style="color: #192d38;">Equipment Booking Dashboard</h1>
 <p class="text-center">This is a placeholder for the equipment booking dashboard.</p>
 {% endblock %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block content %}
-<h1 class="text-center mt-4" style="color: navy;">Automation Dashboard</h1>
+<h1 class="text-center mt-4" style="color: #192d38;">Automation Dashboard</h1>
 
 <section class="mt-4">
     {% if user.is_authenticated %}


### PR DESCRIPTION
## Summary
- switch inline dashboard headers from `navy` to dark grey `#192d38`
- update global stylesheet to use dark grey for body text and links

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68923a24704483259da4234371b75839