### PR TITLE
Prevent page scrolling and make tables scrollable

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -24,6 +24,12 @@
   --input-border: #3c4b5a;
 }
 
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   background-color: var(--bg-color);
   color: #192d38;
@@ -178,6 +184,12 @@ body.sidebar-collapsed #main-content {
   width: 100%;
   height: 10px;
   background-color: #192d38;
+}
+
+.table-responsive {
+  max-height: 80vh;
+  overflow-y: auto;
+  overflow-x: auto;
 }
 
 #zip-progress-container {


### PR DESCRIPTION
## Summary
- Disable overall page scrolling
- Allow long tables to scroll within a fixed viewport height

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68923dd2f63083259b2f848e1fb12977