### PR TITLE
style: curve sidebar intersections with header and footer

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -146,6 +146,8 @@ select:focus {
   color: white;
   display: flex;
   flex-direction: column;
+  border-top-right-radius: 1.25rem;
+  border-bottom-right-radius: 1.25rem;
 }
 
 .sidebar.collapsed {
@@ -184,6 +186,7 @@ body.sidebar-collapsed #main-content {
   width: 100%;
   height: 10px;
   background-color: #192d38;
+  border-top-left-radius: 1.25rem;
 }
 
 .table-responsive {
@@ -209,11 +212,25 @@ body.sidebar-collapsed #main-content {
   color: #192d38;
 }
 
+footer {
+  background-color: #192d38;
+  color: #ccc;
+  width: 100%;
+  border-bottom-left-radius: 1.25rem;
+}
+
 @media (max-width: 768px) {
   #sidebar {
     width: 100%;
     height: auto;
     position: relative;
+    border-radius: 0;
+  }
+  .thin-header {
+    border-top-left-radius: 0;
+  }
+  footer {
+    border-bottom-left-radius: 0;
   }
   body.sidebar-collapsed #main-content {
     margin-left: 0;


### PR DESCRIPTION
## Summary
- add rounded corners to sidebar where it meets header and footer
- give header and footer matching radii for a smoother Apple-like layout
- reset radii on small screens to preserve mobile layout

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68930cedfad0832594ecedf903774c07