### PR TITLE
feat: update background colour

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -15,7 +15,7 @@
 }
 
 :root {
-  --bg-color: #BEDAE5;
+  --bg-color: #244050;
   --text-color: #f1f1f1;
   --accent-start: #05E560;
   --accent-end: #B9FF00;
@@ -45,7 +45,7 @@ a:visited {
 }
 
 body.light-mode {
-  --bg-color: #BEDAE5;
+  --bg-color: #244050;
   --text-color: #222;
   --input-bg: #fff;
   --input-border: #ced4da;


### PR DESCRIPTION
## Summary
- replace existing light blue background with #244050 for default and light modes

## Testing
- `python equipment_booking_app/manage.py test workflow_automation`

------
https://chatgpt.com/codex/tasks/task_e_68930eb4832883258f638f77220170e6