### PR TITLE
Restrict page scroll to tables

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -57,6 +57,7 @@ main {
   flex-direction: column;
   align-items: center;
   text-align: center;
+  overflow: hidden;
 }
 
 h1,
@@ -176,6 +177,13 @@ select:focus {
 
 .logout-container {
   margin-bottom: 2.25rem;
+}
+
+#main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 body.sidebar-collapsed #main-content {


### PR DESCRIPTION
## Summary
- Prevent page-level scrolling by hiding overflow on the main content container and `main` element
- Allow tables to remain scrollable via existing `.table-responsive` styles

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689311ade9508325a8793649311aa1eb