### PR TITLE
Refine sidebar layout and improve text visibility

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -32,7 +32,7 @@ body {
 
 body {
   background-color: var(--bg-color);
-  color: #192d38;
+  color: var(--text-color);
   font-family: 'Bienvenue', sans-serif;
   min-height: 100vh;
   display: flex;
@@ -41,7 +41,7 @@ body {
 
 a,
 a:visited {
-  color: #192d38;
+  color: var(--text-color);
 }
 
 body.light-mode {
@@ -127,7 +127,16 @@ select:focus {
 
 .card {
   background-color: #1e2b38;
-  color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.card a,
+.card a:visited {
+  color: var(--text-color);
+}
+
+.table {
+  color: var(--text-color);
 }
 
 
@@ -190,13 +199,6 @@ body.sidebar-collapsed #main-content {
   margin-left: 110px;
 }
 
-.thin-header {
-  width: 100%;
-  height: 10px;
-  background-color: #192d38;
-  border-top-left-radius: 1.25rem;
-}
-
 .table-responsive {
   max-height: 80vh;
   overflow-y: auto;
@@ -233,9 +235,6 @@ footer {
     height: auto;
     position: relative;
     border-radius: 0;
-  }
-  .thin-header {
-    border-top-left-radius: 0;
   }
   footer {
     border-bottom-left-radius: 0;

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -58,6 +58,7 @@
             display: flex;
             align-items: center;
             font-family: 'Gamechanger', sans-serif;
+            height: 40px;
         }
 
         #sidebar nav a i,
@@ -190,7 +191,6 @@
 <body class="d-flex flex-column min-vh-100 dark-mode">
     {% include 'workflow_automation/partials/sidebar.html' %}
     <div id="main-content" class="flex-grow-1">
-    <header class="thin-header"></header>
     <div id="zip-progress-container" class="fixed-top" style="display:none;">
         <div class="d-flex justify-content-between align-items-center">
             <span id="zip-task-name">Zipping RCP Files</span>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
@@ -2,11 +2,11 @@
 {% load static %}
 
 {% block content %}
-<h1 class="text-center mt-4" style="color: #192d38;">Automation Dashboard</h1>
+<h1 class="text-center mt-4">Automation Dashboard</h1>
 
 <section class="mt-4">
     {% if user.is_authenticated %}
-        <h4 class="text-center mb-4" style="color:#192d38;">Welcome {{ user.username }}</h4>
+        <h4 class="text-center mb-4">Welcome {{ user.username }}</h4>
 
         <div class="container">
             <!-- Priority automation actions -->

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/login.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/login.html
@@ -6,7 +6,7 @@
 
     <h1 class="text-center mb-4" style="color: white;">AtkinsRealis Booking App</h1>
     <!-- Bootstrap card for styling the login form -->
-    <div class="card p-4 w-50" style="color: #192d38;">  
+    <div class="card p-4 w-50">
         <h2 class="text-center mb-4">Login</h2>
 
         <!-- Login form with CSRF token for security -->
@@ -40,7 +40,7 @@
 
         <!-- Link to signup page for users without an account -->
         <div class="text-center mt-3">
-            <p>Don't have an account? <a href="{% url 'signup' %}" style="color: #192d38;">Sign up</a></p>
+            <p>Don't have an account? <a href="{% url 'signup' %}" class="text-light">Sign up</a></p>
         </div>
     </div>
 </div>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
@@ -6,7 +6,7 @@
             <img id="sidebarLogo" src="{% static 'images/Open side bar Logo.png' %}" alt="Logo" class="logo">
         </a>
     </div>
-    <nav class="flex-column mt-4">
+    <nav class="flex-column">
         <hr>
         {% if user.is_authenticated %}
             <a href="{% url 'home' %}" class="nav-link" title="Automation Tools" aria-label="Automation Tools">
@@ -17,7 +17,6 @@
                 <i class="fas fa-calendar-alt"></i>
                 <span class="sidebar-label">Equipment Booking</span>
             </a>
-
             <hr>
             <a href="{% url 'create_booking' %}" class="nav-link" title="Create Booking" aria-label="Create Booking">
                 <i class="fas fa-calendar-plus"></i>
@@ -36,25 +35,26 @@
                 <span class="sidebar-label">Inbox / Help</span>
             </a>
             <hr>
-        {% endif %}
-    </nav>
-    <div class="mt-auto logout-container">
-        {% if not user.is_authenticated %}
-            <a href="{% url 'login' %}" class="auth-btn d-block mb-2" title="Login" aria-label="Login">
+        {% else %}
+            <a href="{% url 'login' %}" class="nav-link" title="Login" aria-label="Login">
                 <i class="fas fa-sign-in-alt"></i>
                 <span class="sidebar-label">Login</span>
             </a>
-            <a href="{% url 'signup' %}" class="auth-btn d-block" title="Sign Up" aria-label="Sign Up">
+            <a href="{% url 'signup' %}" class="nav-link" title="Sign Up" aria-label="Sign Up">
                 <i class="fas fa-user-plus"></i>
                 <span class="sidebar-label">Sign Up</span>
             </a>
-        {% else %}
-            <hr>
-            <a href="{% url 'logout' %}" id="logout-link" class="nav-link" onclick="confirmLogout(event)" title="Logout" aria-label="Logout">
-                <i class="fas fa-sign-out-alt"></i>
-                <span class="sidebar-label">Logout</span>
-            </a>
             <hr>
         {% endif %}
+    </nav>
+    {% if user.is_authenticated %}
+    <div class="mt-auto logout-container">
+        <hr>
+        <a href="{% url 'logout' %}" id="logout-link" class="nav-link" onclick="confirmLogout(event)" title="Logout" aria-label="Logout">
+            <i class="fas fa-sign-out-alt"></i>
+            <span class="sidebar-label">Logout</span>
+        </a>
+        <hr>
     </div>
+    {% endif %}
 </div>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/signup.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/signup.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-center align-items-center" style="min-height: 80vh;">
-    <div class="card p-4 w-100" style="color: #192d38;">
+    <div class="card p-4 w-100">
         <h1 class="text-center mb-4">Sign Up</h1>
         
         <!-- Signup form with CSRF token for security -->
@@ -11,13 +11,12 @@
             <div class="form-group">
                 {{ form.as_p }}  <!-- Render the form fields using Django's form rendering -->
             </div>
-            >
             <button type="submit" class="btn btn-primary btn-block mt-3">Sign Up</button>
         </form>
 
         <!-- Link to login page for users who already have an account -->
         <div class="text-center mt-3">
-            <p>Already have an account? <a href="{% url 'login' %}" style="color: #192d38;">Login</a></p>
+            <p>Already have an account? <a href="{% url 'login' %}" class="text-light">Login</a></p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- remove thin header and fix sidebar button heights
- ensure dark cards and tables use light text
- move login/sign-up links to the top of the sidebar with divider lines

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689314530b308325b6dbec74b00ea22b