### PR TITLE
Ensure gradient button text uses #192d38

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -19,7 +19,6 @@
   --text-color: #f1f1f1;
   --accent-start: #05E560;
   --accent-end: #B9FF00;
-  --button-text-color: #192d38;
   --input-bg: #253545;
   --input-border: #3c4b5a;
 }
@@ -81,7 +80,7 @@ h6 {
 .btn {
   padding: 0.5rem 1rem;
   background-image: linear-gradient(to right, var(--accent-start), var(--accent-end));
-  color: var(--button-text-color);
+  color: #192d38;
   border: none;
   border-radius: 0.375rem;
   text-decoration: none;


### PR DESCRIPTION
## Summary
- set gradient button text color to hex `#192d38`
- remove unused CSS variable for button text color

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689316b711c48325974d8a0ec45cbd0c