### PR TITLE
style: use blue buttons for workflow UI

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -75,16 +75,17 @@ h6 {
   display: block;
 }
 
+
 .nav-link,
 .auth-btn,
 .btn {
   padding: 0.5rem 1rem;
-  background-image: linear-gradient(to right, var(--accent-start), var(--accent-end));
-  color: #192d38;
+  background-color: #192d38;
+  color: #fff;
   border: none;
   border-radius: 0.375rem;
   text-decoration: none;
-  transition: background-image 0.2s ease, transform 0.1s;
+  transition: background-color 0.2s ease, transform 0.1s;
   margin-right: 10px;
   display: inline-block;
 }
@@ -92,7 +93,21 @@ h6 {
 .nav-link:hover,
 .auth-btn:hover,
 .btn:hover {
-  background-image: linear-gradient(to right, var(--accent-end), var(--accent-start));
+  background-color: #1f3b49;
+  color: #fff;
+}
+
+.btn-primary {
+  background-color: #192d38;
+  border-color: #192d38;
+  color: #fff;
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background-color: #1f3b49;
+  border-color: #1f3b49;
+  color: #fff;
 }
 
 .btn:active,

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -118,18 +118,18 @@
     
         .nav-link {
             padding: 10px 20px;
-            background-image: linear-gradient(to right, #05E560, #B9FF00);
-            color: #192d38;
+            background-color: #192d38;
+            color: #fff;
             border-radius: 10px;
             text-decoration: none;
-            transition: background-image 0.3s ease;
+            transition: background-color 0.3s ease;
             margin-right: 10px;
             display: inline-block;
         }
 
         .nav-link:hover {
-            background-image: linear-gradient(to right, #B9FF00, #05E560);
-            color: #192d38;
+            background-color: #1f3b49;
+            color: #fff;
         }
     
         #logout-link {
@@ -138,33 +138,46 @@
         }
     
         .auth-btn {
-            background-image: linear-gradient(to right, #05E560, #B9FF00);
-            color: #192d38;
+            background-color: #192d38;
+            color: #fff;
             border: none;
             padding: 10px 20px;
             border-radius: 10px;
             font-size: 1.2rem;
             margin-right: 10px;
-            transition: background-image 0.3s ease;
+            transition: background-color 0.3s ease;
             display: inline-block;
         }
 
         .auth-btn:hover {
-            background-image: linear-gradient(to right, #B9FF00, #05E560);
-            color: #192d38;
+            background-color: #1f3b49;
+            color: #fff;
         }
     
         .btn {
-            background-image: linear-gradient(to right, #05E560, #B9FF00);
-            color: #192d38;
+            background-color: #192d38;
+            color: #fff;
             border: none;
             margin-right: 10px;
             border-radius: 10px;
         }
 
         .btn:hover {
-            background-image: linear-gradient(to right, #B9FF00, #05E560);
-            color: #192d38;
+            background-color: #1f3b49;
+            color: #fff;
+        }
+
+        .btn-primary {
+            background-color: #192d38;
+            border-color: #192d38;
+            color: #fff;
+        }
+
+        .btn-primary:hover,
+        .btn-primary:focus {
+            background-color: #1f3b49;
+            border-color: #1f3b49;
+            color: #fff;
         }
 
         /* Sidebar spacing */


### PR DESCRIPTION
## Summary
- switch nav links and buttons to solid #192d38 with white text
- style Bootstrap primary buttons to match sidebar scheme

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68931a488bbc8325bd2ce0e09486701d