### PR TITLE
Use white text for readability across site

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -80,7 +80,7 @@ h6 {
 .btn {
   padding: 0.5rem 1rem;
   background-image: linear-gradient(to right, var(--accent-start), var(--accent-end));
-  color: #192d38;
+  color: var(--text-color);
   border: none;
   border-radius: 0.375rem;
   text-decoration: none;
@@ -218,12 +218,12 @@ body.sidebar-collapsed #main-content {
 
 #zip-progress-container .progress-bar {
   background-image: linear-gradient(to right, var(--accent-start), var(--accent-end));
-  color: #192d38;
+  color: var(--text-color);
 }
 
 footer {
   background-color: #192d38;
-  color: #ccc;
+  color: var(--text-color);
   width: 100%;
   border-bottom-left-radius: 1.25rem;
 }

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/account_detail.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/account_detail.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">Your Account Details</h2>
 
     <!-- Card for form layout with Bootstrap styling -->
-    <div class="card p-4 w-50 mx-auto mb-5" style="color: #192d38;">
+    <div class="card p-4 w-50 mx-auto mb-5" style="color: var(--text-color);">
         <form method="post" action="{% url 'accounts' %}">
             {% csrf_token %}
 

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -119,7 +119,7 @@
         .nav-link {
             padding: 10px 20px;
             background-image: linear-gradient(to right, #05E560, #B9FF00);
-            color: #192d38;
+            color: var(--text-color);
             border-radius: 10px;
             text-decoration: none;
             transition: background-image 0.3s ease;
@@ -129,7 +129,7 @@
 
         .nav-link:hover {
             background-image: linear-gradient(to right, #B9FF00, #05E560);
-            color: #192d38;
+            color: var(--text-color);
         }
     
         #logout-link {
@@ -139,7 +139,7 @@
     
         .auth-btn {
             background-image: linear-gradient(to right, #05E560, #B9FF00);
-            color: #192d38;
+            color: var(--text-color);
             border: none;
             padding: 10px 20px;
             border-radius: 10px;
@@ -151,12 +151,12 @@
 
         .auth-btn:hover {
             background-image: linear-gradient(to right, #B9FF00, #05E560);
-            color: #192d38;
+            color: var(--text-color);
         }
     
         .btn {
             background-image: linear-gradient(to right, #05E560, #B9FF00);
-            color: #192d38;
+            color: var(--text-color);
             border: none;
             margin-right: 10px;
             border-radius: 10px;
@@ -164,7 +164,7 @@
 
         .btn:hover {
             background-image: linear-gradient(to right, #B9FF00, #05E560);
-            color: #192d38;
+            color: var(--text-color);
         }
 
         /* Sidebar spacing */
@@ -239,7 +239,7 @@
     </main>
     </div>
 
-    <footer class="mt-auto py-1 text-center" style="background-color: #192d38; color: #ccc; width: 100%;">
+    <footer class="mt-auto py-1 text-center" style="background-color: #192d38; color: var(--text-color); width: 100%;">
         © Curtis Hailes, AtkinsRéalis 2025
     </footer>
     

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/booking_list.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/booking_list.html
@@ -14,7 +14,7 @@
     <!-- Responsive table for displaying upcoming bookings -->
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: var(--text-color); font-size: 1.25rem; text-align: center;">
                 <tr class="text-center">
                     {% if is_superuser %}
                         <th>User</th> 
@@ -72,7 +72,7 @@
     <h2 class="text-center mb-4 mt-5">Previous Bookings</h2>
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;"> <!-- Table header for previous bookings -->
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: var(--text-color); font-size: 1.25rem; text-align: center;"> <!-- Table header for previous bookings -->
                 <tr class="text-center">
                     {% if is_superuser %}
                         <th>User</th> <!-- Display user for superusers -->

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/contact.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/contact.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">Submit Question or Workflow</h2>
 
     <!-- Card for styling the content, similar to booking form design -->
-    <div class="card p-4 w-75 mx-auto mb-5" style="color: #192d38;">
+    <div class="card p-4 w-75 mx-auto mb-5" style="color: var(--text-color);">
         
         <!-- Check if the user is authenticated -->
         {% if user.is_authenticated %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/create_booking.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/create_booking.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">Create Booking</h2>
 
    
-    <div class="card p-4 w-50 mx-auto mb-5" style="color: #192d38;">
+    <div class="card p-4 w-50 mx-auto mb-5" style="color: var(--text-color);">
         <form method="post">
             {% csrf_token %}
 

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/edit_booking.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/edit_booking.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">Edit Booking</h2>
 
     <!-- Box around the form (Bootstrap card) with a white background and text color adjusted -->
-    <div class="card p-4 w-50 mx-auto mb-5" style="color: #192d38;">
+    <div class="card p-4 w-50 mx-auto mb-5" style="color: var(--text-color);">
         <form method="post">
             {% csrf_token %}
 

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
@@ -1,6 +1,6 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<h1 class="text-center mt-4" style="color: #192d38;">Equipment Booking Dashboard</h1>
+<h1 class="text-center mt-4" style="color: var(--text-color);">Equipment Booking Dashboard</h1>
 <p class="text-center">This is a placeholder for the equipment booking dashboard.</p>
 {% endblock %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/inbox.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/inbox.html
@@ -6,7 +6,7 @@
     {% if pending_workflows %}
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: var(--text-color); font-size: 1.25rem; text-align: center;">
                 <tr class="text-center">
                     <th>Workflow</th>
                     <th>Submitted By</th>
@@ -48,7 +48,7 @@
     {% if unread_messages %}
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: var(--text-color); font-size: 1.25rem; text-align: center;">
                 <tr class="text-center">
                     <th>Sender</th>
                     <th>Subject</th>
@@ -86,7 +86,7 @@
     {% if read_messages %}
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: var(--text-color); font-size: 1.25rem; text-align: center;">
                 <tr class="text-center">
                     <th>Sender</th>
                     <th>Subject</th>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
@@ -3,9 +3,9 @@
 
 {% block content %}
 {% if user.is_authenticated %}
-<h1 class="text-center mt-4" style="color: #192d38;">Welcome {{ user.username }}</h1>
+<h1 class="text-center mt-4" style="color: var(--text-color);">Welcome {{ user.username }}</h1>
 {% else %}
-<h1 class="text-center mt-4" style="color: #192d38;">Welcome</h1>
+<h1 class="text-center mt-4" style="color: var(--text-color);">Welcome</h1>
 {% endif %}
 
 <div class="container mt-4">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/my_workflows.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/my_workflows.html
@@ -14,7 +14,7 @@
 </div>
 <div class="table-responsive mb-5">
 <table id="my-workflows" class="table table-striped table-bordered table-hover w-100" style="background-color:#ffffff; width:100%;">
-<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:#192d38; text-align:center;">
+<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:var(--text-color); text-align:center;">
 <tr><th>Name</th><th>Status</th><th>Actions</th></tr>
 </thead>
 <tbody>
@@ -67,7 +67,7 @@
 <h3 class="text-center mb-4">Imported Workflows</h3>
 <div class="table-responsive">
 <table class="table table-striped table-bordered table-hover w-100" style="background-color:#ffffff; width:100%;">
-<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:#192d38; text-align:center;">
+<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:var(--text-color); text-align:center;">
 <tr><th>Name</th><th>Source</th><th>Status</th><th>Actions</th></tr>
 </thead>
 <tbody>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/pause_confirmation.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/pause_confirmation.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="text-center mb-4">Step completed: {{ step_name }}</h2>
-<div class="w-75 mx-auto" style="color:#192d38;">
+<div class="w-75 mx-auto" style="color:var(--text-color);">
     <ul class="list-group mb-3">
     {% for line in step_logs %}
         <li class="list-group-item">{{ line }}</li>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/previous_bookings.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/previous_bookings.html
@@ -6,7 +6,7 @@
 
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: var(--text-color); font-size: 1.25rem; text-align: center;">
                 <!-- Table headers for user, item, start time, and end time -->
                 <tr class="text-center">
                     <th>User</th>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/shared_workflows.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/shared_workflows.html
@@ -10,7 +10,7 @@
 
 <div class="table-responsive">
 <table class="table table-striped table-bordered table-hover w-100" style="background-color:#ffffff; width:100%;">
-<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:#192d38; text-align:center;">
+<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:var(--text-color); text-align:center;">
 <tr><th>Name</th><th>Description</th><th>Author</th><th>Actions</th></tr>
 </thead>
 <tbody>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/video_review.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/video_review.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="text-center mb-4">Video QA Review</h2>
-<div class="w-75 mx-auto" style="color:#192d38;">
+<div class="w-75 mx-auto" style="color:var(--text-color);">
     <img src="{{ preview_url }}" class="img-fluid mb-3" alt="Video preview">
     <p class="mb-2"><strong>Edit</strong><br>
         Cropping: {{ crop_start }}s start, {{ crop_end }}s end<br>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_dashboard.html
@@ -11,7 +11,7 @@
 {% if workflows %}
     <ul class="list-group">
     {% for workflow in workflows %}
-        <li class="list-group-item" style="color:#192d38;">
+        <li class="list-group-item" style="color:var(--text-color);">
             <strong>{{ workflow.name }}</strong> - {{ workflow.description }}
             <ul class="mb-2">
                 {% for step in workflow.steps.all %}
@@ -24,7 +24,7 @@
 {% elif recent_runs %}
     <div class="table-responsive">
     <table class="table table-striped table-bordered table-hover w-100" style="background-color:#ffffff;">
-        <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:#192d38; text-align:center;">
+        <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:var(--text-color); text-align:center;">
             <tr><th>Name</th><th>Last Used</th><th>Actions</th></tr>
         </thead>
         <tbody>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_progress.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_progress.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h2 class="text-center mb-4">Workflow Progress</h2>
-<div class="w-75 mx-auto" style="color:#192d38;">
+<div class="w-75 mx-auto" style="color:var(--text-color);">
     <ul class="list-group mb-3">
     {% for line in logs %}
         <li class="list-group-item">{{ line }}</li>


### PR DESCRIPTION
## Summary
- Switch navigation buttons and progress components to use the global text color for better contrast.
- Replace dark inline styles with the shared text color variable on account and booking templates.

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68931a9b8a84832580c6a3cf66366b2d