### PR TITLE
Show inbox only for admins

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
@@ -31,14 +31,20 @@
             </div>
 
             <!-- Secondary actions -->
-            <div class="row g-3 mb-4 text-center">
-                <div class="col-12 col-sm-6 col-md-4 col-lg-3">
-                    <a href="{% url 'create_booking' %}" class="btn btn-secondary btn-lg w-100">Book Equipment</a>
+                <div class="row g-3 mb-4 text-center">
+                    <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+                        <a href="{% url 'create_booking' %}" class="btn btn-secondary btn-lg w-100">Book Equipment</a>
+                    </div>
+                    {% if user.is_superuser %}
+                    <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+                        <a href="{% url 'inbox' %}" class="btn btn-secondary btn-lg w-100">Inbox</a>
+                    </div>
+                    {% else %}
+                    <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+                        <a href="{% url 'contact' %}" class="btn btn-secondary btn-lg w-100">Contact / Help</a>
+                    </div>
+                    {% endif %}
                 </div>
-                <div class="col-12 col-sm-6 col-md-4 col-lg-3">
-                    <a href="{% url 'contact' %}" class="btn btn-secondary btn-lg w-100">Contact / Help</a>
-                </div>
-            </div>
         </div>
 
         {% if notice %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar.html
@@ -30,10 +30,17 @@
                 <i class="fas fa-user-circle"></i>
                 <span class="sidebar-label">Profile</span>
             </a>
-            <a href="{% url 'inbox' %}" class="nav-link" title="Inbox / Help" aria-label="Inbox / Help">
+            {% if user.is_superuser %}
+            <a href="{% url 'inbox' %}" class="nav-link" title="Inbox" aria-label="Inbox">
                 <i class="fas fa-inbox"></i>
-                <span class="sidebar-label">Inbox / Help</span>
+                <span class="sidebar-label">Inbox</span>
             </a>
+            {% else %}
+            <a href="{% url 'contact' %}" class="nav-link" title="Help" aria-label="Help">
+                <i class="fas fa-inbox"></i>
+                <span class="sidebar-label">Help</span>
+            </a>
+            {% endif %}
             <hr>
         {% else %}
             <a href="{% url 'login' %}" class="nav-link" title="Login" aria-label="Login">

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -358,10 +358,35 @@ class SidebarLinksTests(TestCase):
         response = self.client.get(reverse("home"))
         self.assertContains(response, reverse("accounts"))
 
+    def test_help_link_visible_for_regular_user(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("home"))
+        self.assertContains(response, reverse("contact"))
+        self.assertNotContains(response, reverse("inbox"))
+
     def test_inbox_link_visible_for_superuser(self):
         self.client.force_login(self.admin)
         response = self.client.get(reverse("home"))
         self.assertContains(response, reverse("inbox"))
+        self.assertNotContains(response, reverse("contact"))
+
+
+class ContactPageTests(TestCase):
+    def setUp(self):
+        self.user_no_email = User.objects.create_user(username="noemail", password="pass")
+        self.user_with_email = User.objects.create_user(
+            username="withemail", password="pass", email="user@example.com"
+        )
+
+    def test_requires_email_to_send_message(self):
+        self.client.force_login(self.user_no_email)
+        response = self.client.get(reverse("contact"))
+        self.assertRedirects(response, reverse("accounts"))
+
+    def test_form_displayed_when_email_present(self):
+        self.client.force_login(self.user_with_email)
+        response = self.client.get(reverse("contact"))
+        self.assertContains(response, "Send Message")
 
 
 class WorkflowDeleteTests(TestCase):


### PR DESCRIPTION
## Summary
- Show Inbox in navigation for superusers and Help for regular users
- Adjust dashboard to display Inbox or Contact accordingly
- Test link visibility and email requirement on contact page

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68931e1ec39c832596c959cbd116af8c