### PR TITLE
feat: split sidebar by section

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -202,7 +202,11 @@
     <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 </head>
 <body class="d-flex flex-column min-vh-100 dark-mode">
-    {% include 'workflow_automation/partials/sidebar.html' %}
+    {% if request.path.startswith('/automation/') %}
+        {% include 'workflow_automation/partials/sidebar_automation.html' %}
+    {% elif request.path.startswith('/equipment/') %}
+        {% include 'workflow_automation/partials/sidebar_booking.html' %}
+    {% endif %}
     <div id="main-content" class="flex-grow-1">
     <div id="zip-progress-container" class="fixed-top" style="display:none;">
         <div class="d-flex justify-content-between align-items-center">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_automation.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_automation.html
@@ -1,0 +1,79 @@
+{% load static %}
+<div id="sidebar" class="sidebar">
+    <div class="d-flex align-items-center">
+        <button id="sidebarToggle" class="toggle-btn mr-2">&#9776;</button>
+        <a href="{% url 'launcher' %}">
+            <img id="sidebarLogo" src="{% static 'images/Open side bar Logo.png' %}" alt="Logo" class="logo">
+        </a>
+    </div>
+    <nav class="flex-column">
+        <hr>
+        {% if user.is_authenticated %}
+            <span class="text-light px-3">Quick Links</span>
+            <a href="{% url 'home' %}" class="nav-link" title="Automation Home" aria-label="Automation Home">
+                <i class="fas fa-robot"></i>
+                <span class="sidebar-label">Automation Home</span>
+            </a>
+            <a href="{% url 'my_workflows' %}" class="nav-link" title="My Workflows" aria-label="My Workflows">
+                <i class="fas fa-list"></i>
+                <span class="sidebar-label">My Workflows</span>
+            </a>
+            <a href="{% url 'create_workflow' %}" class="nav-link" title="Create Workflow" aria-label="Create Workflow">
+                <i class="fas fa-plus-circle"></i>
+                <span class="sidebar-label">Create Workflow</span>
+            </a>
+            <a href="{% url 'run_workflow' %}" class="nav-link" title="Run Workflow" aria-label="Run Workflow">
+                <i class="fas fa-play-circle"></i>
+                <span class="sidebar-label">Run Workflow</span>
+            </a>
+            <a href="{% url 'shared_workflows' %}" class="nav-link" title="Shared Workflows" aria-label="Shared Workflows">
+                <i class="fas fa-share-alt"></i>
+                <span class="sidebar-label">Shared Workflows</span>
+            </a>
+            {% if user.is_superuser %}
+            <a href="{% url 'review_workflows' %}" class="nav-link" title="Review Requests" aria-label="Review Requests">
+                <i class="fas fa-check-circle"></i>
+                <span class="sidebar-label">Review Requests</span>
+            </a>
+            {% endif %}
+            <hr>
+            <span class="text-light px-3">Account</span>
+            <a href="{% url 'accounts' %}" class="nav-link" title="Profile" aria-label="Profile">
+                <i class="fas fa-user-circle"></i>
+                <span class="sidebar-label">Profile</span>
+            </a>
+            {% if user.is_superuser %}
+            <a href="{% url 'inbox' %}" class="nav-link" title="Inbox" aria-label="Inbox">
+                <i class="fas fa-inbox"></i>
+                <span class="sidebar-label">Inbox</span>
+            </a>
+            {% else %}
+            <a href="{% url 'contact' %}" class="nav-link" title="Help" aria-label="Help">
+                <i class="fas fa-question-circle"></i>
+                <span class="sidebar-label">Help</span>
+            </a>
+            {% endif %}
+            <hr>
+        {% else %}
+            <a href="{% url 'login' %}" class="nav-link" title="Login" aria-label="Login">
+                <i class="fas fa-sign-in-alt"></i>
+                <span class="sidebar-label">Login</span>
+            </a>
+            <a href="{% url 'signup' %}" class="nav-link" title="Sign Up" aria-label="Sign Up">
+                <i class="fas fa-user-plus"></i>
+                <span class="sidebar-label">Sign Up</span>
+            </a>
+            <hr>
+        {% endif %}
+    </nav>
+    {% if user.is_authenticated %}
+    <div class="mt-auto logout-container">
+        <hr>
+        <a href="{% url 'logout' %}" id="logout-link" class="nav-link" onclick="confirmLogout(event)" title="Logout" aria-label="Logout">
+            <i class="fas fa-sign-out-alt"></i>
+            <span class="sidebar-label">Logout</span>
+        </a>
+        <hr>
+    </div>
+    {% endif %}
+</div>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
@@ -9,26 +9,22 @@
     <nav class="flex-column">
         <hr>
         {% if user.is_authenticated %}
-            <a href="{% url 'home' %}" class="nav-link" title="Automation Tools" aria-label="Automation Tools">
-                <i class="fas fa-robot"></i>
-                <span class="sidebar-label">Automation Tools</span>
-            </a>
-            <a href="{% url 'equipment_dashboard' %}" class="nav-link" title="Equipment Booking" aria-label="Equipment Booking">
+            <span class="text-light px-3">Quick Links</span>
+            <a href="{% url 'equipment_dashboard' %}" class="nav-link" title="Equipment Home" aria-label="Equipment Home">
                 <i class="fas fa-calendar-alt"></i>
-                <span class="sidebar-label">Equipment Booking</span>
+                <span class="sidebar-label">Equipment Home</span>
             </a>
-            <hr>
             <a href="{% url 'create_booking' %}" class="nav-link" title="Create Booking" aria-label="Create Booking">
                 <i class="fas fa-calendar-plus"></i>
                 <span class="sidebar-label">Create Booking</span>
             </a>
-            <a href="{% url 'my_workflows' %}" class="nav-link" title="My Workflows" aria-label="My Workflows">
-                <i class="fas fa-list"></i>
-                <span class="sidebar-label">My Workflows</span>
+            <a href="{% url 'my_bookings' %}" class="nav-link" title="My Bookings" aria-label="My Bookings">
+                <i class="fas fa-book"></i>
+                <span class="sidebar-label">My Bookings</span>
             </a>
-            <a href="{% url 'accounts' %}" class="nav-link" title="Profile" aria-label="Profile">
-                <i class="fas fa-user-circle"></i>
-                <span class="sidebar-label">Profile</span>
+            <a href="{% url 'previous_bookings' %}" class="nav-link" title="Previous Bookings" aria-label="Previous Bookings">
+                <i class="fas fa-history"></i>
+                <span class="sidebar-label">Previous Bookings</span>
             </a>
             {% if user.is_superuser %}
             <a href="{% url 'inbox' %}" class="nav-link" title="Inbox" aria-label="Inbox">
@@ -37,10 +33,16 @@
             </a>
             {% else %}
             <a href="{% url 'contact' %}" class="nav-link" title="Help" aria-label="Help">
-                <i class="fas fa-inbox"></i>
+                <i class="fas fa-question-circle"></i>
                 <span class="sidebar-label">Help</span>
             </a>
             {% endif %}
+            <hr>
+            <span class="text-light px-3">Account</span>
+            <a href="{% url 'accounts' %}" class="nav-link" title="Profile" aria-label="Profile">
+                <i class="fas fa-user-circle"></i>
+                <span class="sidebar-label">Profile</span>
+            </a>
             <hr>
         {% else %}
             <a href="{% url 'login' %}" class="nav-link" title="Login" aria-label="Login">


### PR DESCRIPTION
## Summary
- Dynamically include an automation or equipment sidebar based on the current URL path
- Add dedicated automation sidebar with workflow shortcuts and account links
- Add dedicated equipment sidebar with booking links and account links

## Testing
- `python equipment_booking_app/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68934a9de3308325be5391367e43e42a