### PR TITLE
Add booking dashboard shortcuts and admin link

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -202,9 +202,9 @@
     <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 </head>
 <body class="d-flex flex-column min-vh-100 dark-mode">
-    {% if request.path.startswith('/automation/') %}
+    {% if '/automation/' in request.path %}
         {% include 'workflow_automation/partials/sidebar_automation.html' %}
-    {% elif request.path.startswith('/equipment/') %}
+    {% elif '/equipment/' in request.path %}
         {% include 'workflow_automation/partials/sidebar_booking.html' %}
     {% endif %}
     <div id="main-content" class="flex-grow-1">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
@@ -2,5 +2,29 @@
 
 {% block content %}
 <h1 class="text-center mt-4" style="color: #192d38;">Equipment Booking Dashboard</h1>
-<p class="text-center">This is a placeholder for the equipment booking dashboard.</p>
+
+{% if user.is_authenticated %}
+<div class="container mt-4">
+    <div class="row g-3 mb-4 text-center">
+        <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+            <a href="{% url 'create_booking' %}" class="btn btn-primary btn-lg w-100">Create Booking</a>
+        </div>
+        <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+            <a href="{% url 'my_bookings' %}" class="btn btn-primary btn-lg w-100">My Bookings</a>
+        </div>
+        {% if user.is_superuser %}
+        <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+            <a href="{% url 'inbox' %}" class="btn btn-primary btn-lg w-100">Inbox</a>
+        </div>
+        {% endif %}
+        {% if user.is_staff %}
+        <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+            <a href="{% url 'admin:index' %}" class="btn btn-primary btn-lg w-100">Admin Tools</a>
+        </div>
+        {% endif %}
+    </div>
+</div>
+{% else %}
+<p class="text-center">Please <a href="{% url 'login' %}" class="btn btn-primary">Login</a> or <a href="{% url 'signup' %}" class="btn btn-primary">Sign Up</a> to book equipment.</p>
+{% endif %}
 {% endblock %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
@@ -37,6 +37,12 @@
                 <span class="sidebar-label">Help</span>
             </a>
             {% endif %}
+            {% if user.is_staff %}
+            <a href="{% url 'admin:index' %}" class="nav-link" title="Admin Tools" aria-label="Admin Tools">
+                <i class="fas fa-tools"></i>
+                <span class="sidebar-label">Admin Tools</span>
+            </a>
+            {% endif %}
             <hr>
             <span class="text-light px-3">Account</span>
             <a href="{% url 'accounts' %}" class="nav-link" title="Profile" aria-label="Profile">


### PR DESCRIPTION
## Summary
- replace placeholder equipment dashboard with navigation buttons for creating and viewing bookings, inbox access, and staff admin tools
- add Admin Tools quick link to equipment sidebar
- fix template sidebar selection logic to use path membership checks

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68934c5102b8832592f29e67e9041b43