### PR TITLE
Ensure sidebars render on all pages

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -202,12 +202,12 @@
     <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 </head>
 <body class="d-flex flex-column min-vh-100 dark-mode">
-    {% if '/automation/' in request.path %}
-        {% include 'workflow_automation/partials/sidebar_automation.html' %}
-    {% elif '/equipment/' in request.path %}
-        {% include 'workflow_automation/partials/sidebar_booking.html' %}
-    {% elif request.path == '/' %}
+    {% if request.path == '/' %}
         {% include 'workflow_automation/partials/sidebar_launcher.html' %}
+    {% elif 'equipment' in request.path or 'booking' in request.path %}
+        {% include 'workflow_automation/partials/sidebar_booking.html' %}
+    {% else %}
+        {% include 'workflow_automation/partials/sidebar_automation.html' %}
     {% endif %}
     <div id="main-content" class="flex-grow-1">
     <div id="zip-progress-container" class="fixed-top" style="display:none;">


### PR DESCRIPTION
## Summary
- Load equipment booking or automation sidebars based on request path
- Default to automation features so every page displays a sidebar

## Testing
- `pip install -r equipment_booking_app/requirements.txt`
- `cd equipment_booking_app && python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689352f7aa788325aecfe1067c6bcefc