### PR TITLE
Ensure contact/profile sidebars match home layout

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -202,7 +202,7 @@
     <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 </head>
 <body class="d-flex flex-column min-vh-100 dark-mode">
-    {% if request.path == '/' %}
+    {% if request.path == '/' or 'contact' in request.path or 'accounts' in request.path %}
         {% include 'workflow_automation/partials/sidebar_launcher.html' %}
     {% elif 'equipment' in request.path or 'booking' in request.path %}
         {% include 'workflow_automation/partials/sidebar_booking.html' %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_automation.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_automation.html
@@ -42,15 +42,14 @@
                 <i class="fas fa-user-circle"></i>
                 <span class="sidebar-label">Profile</span>
             </a>
+            <a href="{% url 'contact' %}" class="nav-link" title="Contact" aria-label="Contact">
+                <i class="fas fa-envelope"></i>
+                <span class="sidebar-label">Contact</span>
+            </a>
             {% if user.is_superuser %}
             <a href="{% url 'inbox' %}" class="nav-link" title="Inbox" aria-label="Inbox">
                 <i class="fas fa-inbox"></i>
                 <span class="sidebar-label">Inbox</span>
-            </a>
-            {% else %}
-            <a href="{% url 'contact' %}" class="nav-link" title="Help" aria-label="Help">
-                <i class="fas fa-question-circle"></i>
-                <span class="sidebar-label">Help</span>
             </a>
             {% endif %}
             <hr>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
@@ -26,15 +26,14 @@
                 <i class="fas fa-history"></i>
                 <span class="sidebar-label">Previous Bookings</span>
             </a>
+            <a href="{% url 'contact' %}" class="nav-link" title="Contact" aria-label="Contact">
+                <i class="fas fa-envelope"></i>
+                <span class="sidebar-label">Contact</span>
+            </a>
             {% if user.is_superuser %}
             <a href="{% url 'inbox' %}" class="nav-link" title="Inbox" aria-label="Inbox">
                 <i class="fas fa-inbox"></i>
                 <span class="sidebar-label">Inbox</span>
-            </a>
-            {% else %}
-            <a href="{% url 'contact' %}" class="nav-link" title="Help" aria-label="Help">
-                <i class="fas fa-question-circle"></i>
-                <span class="sidebar-label">Help</span>
             </a>
             {% endif %}
             {% if user.is_staff %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_launcher.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_launcher.html
@@ -41,6 +41,12 @@
                 <span class="sidebar-label">Contact</span>
             </a>
             <hr>
+            <span class="text-light px-3">Account</span>
+            <a href="{% url 'accounts' %}" class="nav-link" title="Profile" aria-label="Profile">
+                <i class="fas fa-user-circle"></i>
+                <span class="sidebar-label">Profile</span>
+            </a>
+            <hr>
         {% else %}
             <a href="{% url 'login' %}" class="nav-link" title="Login" aria-label="Login">
                 <i class="fas fa-sign-in-alt"></i>

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -364,11 +364,11 @@ class SidebarLinksTests(TestCase):
         self.assertContains(response, reverse("contact"))
         self.assertNotContains(response, reverse("inbox"))
 
-    def test_inbox_link_visible_for_superuser(self):
+    def test_contact_and_inbox_visible_for_superuser(self):
         self.client.force_login(self.admin)
         response = self.client.get(reverse("home"))
         self.assertContains(response, reverse("inbox"))
-        self.assertNotContains(response, reverse("contact"))
+        self.assertContains(response, reverse("contact"))
 
 
 class ContactPageTests(TestCase):


### PR DESCRIPTION
## Summary
- Show Contact button on equipment and automation sidebars for all users
- Add profile link to home sidebar and reuse home sidebar on Contact and Profile pages
- Update tests for new sidebar expectations

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6893567d74d48325818a75be08fe2498