### PR TITLE
Reorganize contact link in automation sidebar

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_automation.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_automation.html
@@ -30,6 +30,10 @@
                 <i class="fas fa-share-alt"></i>
                 <span class="sidebar-label">Shared Workflows</span>
             </a>
+            <a href="{% url 'contact' %}" class="nav-link" title="Contact" aria-label="Contact">
+                <i class="fas fa-envelope"></i>
+                <span class="sidebar-label">Contact</span>
+            </a>
             {% if user.is_superuser %}
             <a href="{% url 'review_workflows' %}" class="nav-link" title="Review Requests" aria-label="Review Requests">
                 <i class="fas fa-check-circle"></i>
@@ -41,10 +45,6 @@
             <a href="{% url 'accounts' %}" class="nav-link" title="Profile" aria-label="Profile">
                 <i class="fas fa-user-circle"></i>
                 <span class="sidebar-label">Profile</span>
-            </a>
-            <a href="{% url 'contact' %}" class="nav-link" title="Contact" aria-label="Contact">
-                <i class="fas fa-envelope"></i>
-                <span class="sidebar-label">Contact</span>
             </a>
             {% if user.is_superuser %}
             <a href="{% url 'inbox' %}" class="nav-link" title="Inbox" aria-label="Inbox">


### PR DESCRIPTION
## Summary
- relocate Contact link from Account section to Quick Links for automation pages

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6893598d25d8832595b9e32c13de207b