### PR TITLE
fix: widen collapsed sidebar to fit quick links

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -175,7 +175,7 @@ select:focus {
 }
 
 .sidebar.collapsed {
-  width: 110px;
+  width: 130px;
 }
 
 .sidebar .toggle-btn {
@@ -210,7 +210,7 @@ select:focus {
 }
 
 body.sidebar-collapsed #main-content {
-  margin-left: 110px;
+  margin-left: 130px;
 }
 
 .table-responsive {

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -31,7 +31,7 @@
         }
 
         #sidebar.collapsed {
-            width: 110px;
+            width: 130px;
         }
 
         #sidebar .toggle-btn {
@@ -47,7 +47,7 @@
         }
 
         body.sidebar-collapsed #main-content {
-            margin-left: 110px;
+            margin-left: 130px;
         }
 
         /* Sidebar icon and label behaviour */


### PR DESCRIPTION
## Summary
- increase collapsed sidebar width to keep Quick Links text on one line
- align main content margin with new collapsed width

## Testing
- `pytest`
- `python equipment_booking_app/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68936066a0288325ae40db5f31302d25