### PR TITLE
Align collapsed sidebar icons to left

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -178,6 +178,20 @@ select:focus {
   width: 130px;
 }
 
+.sidebar.collapsed .nav-link,
+.sidebar.collapsed .auth-btn,
+.sidebar.collapsed #logout-link,
+.sidebar.collapsed button:not(#sidebarToggle) {
+  justify-content: flex-start;
+}
+
+.sidebar.collapsed .nav-link i,
+.sidebar.collapsed .auth-btn i,
+.sidebar.collapsed #logout-link i,
+.sidebar.collapsed button:not(#sidebarToggle) i {
+  margin-right: 0;
+}
+
 .sidebar .toggle-btn {
   background: none;
   border: none;

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -80,7 +80,7 @@
         #sidebar.collapsed .auth-btn,
         #sidebar.collapsed #logout-link,
         #sidebar.collapsed button:not(#sidebarToggle) {
-            justify-content: center;
+            justify-content: flex-start;
         }
 
         #sidebar.collapsed nav a i,


### PR DESCRIPTION
## Summary
- Keep collapsed sidebar icons aligned to the left instead of centered
- Mirror collapsed alignment and icon spacing rules in static CSS

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689363389ca083259398618c024f8da2