### PR TITLE
Make account page fields consistent and update save button

### DIFF
--- a/equipment_booking_app/workflow_automation/forms.py
+++ b/equipment_booking_app/workflow_automation/forms.py
@@ -52,8 +52,9 @@ class ProfileForm(forms.ModelForm):
         self.fields['work_address'].widget.attrs.update({'class': 'form-control'})
         self.fields['work_division'].widget.attrs.update({'class': 'form-control'})
         self.fields['job_role'].widget.attrs.update({'class': 'form-control'})
+        self.fields['email'].widget.attrs.update({'class': 'form-control'})
         if 'instance' in kwargs:
-            self.fields['email'].initial = kwargs['instance'].user.email  
+            self.fields['email'].initial = kwargs['instance'].user.email
 
     def save(self, commit=True):
         profile = super(ProfileForm, self).save(commit=False)

--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -105,15 +105,28 @@ h6 {
 
 .btn-primary:hover,
 .btn-primary:focus {
-  background-color: #1f3b49;
-  border-color: #1f3b49;
-  color: #fff;
+    background-color: #1f3b49;
+    border-color: #1f3b49;
+    color: #fff;
 }
 
 .btn:active,
 .auth-btn:active,
 .nav-link:active {
-  transform: scale(0.97);
+    transform: scale(0.97);
+}
+
+/* Custom button for account save changes */
+.btn-save-changes {
+    background-color: #73D567;
+    color: #192d38;
+    border: none;
+}
+
+.btn-save-changes:hover,
+.btn-save-changes:focus {
+    background-color: #66c45b;
+    color: #192d38;
 }
 
 input[type="text"],

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/account_detail.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/account_detail.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">Your Account Details</h2>
 
     <!-- Card for form layout with Bootstrap styling -->
-    <div class="card p-4 content-box mb-5" style="color: #192d38;">
+    <div class="card p-4 content-box mb-5">
         <form method="post" action="{% url 'accounts' %}">
             {% csrf_token %}
 
@@ -59,13 +59,13 @@
                 </div>
             </div>
 
-            <!-- Display fixed company name as plaintext -->
+            <!-- Display fixed company name in a readonly input -->
             <div class="row mb-3">
                 <div class="col-4 text-right">
                     <label>Company:</label>
                 </div>
                 <div class="col-8">
-                    <p class="form-control-plaintext">{{ fixed_company }}</p>
+                    <input type="text" class="form-control" value="{{ fixed_company }}" readonly>
                 </div>
             </div>
 
@@ -89,18 +89,18 @@
                 </div>
             </div>
 
-            <!-- Display user type as plaintext -->
+            <!-- Display user type in a readonly input -->
             <div class="row mb-3">
                 <div class="col-4 text-right">
                     <label>User Type:</label>
                 </div>
                 <div class="col-8">
-                    <p class="form-control-plaintext">{{ user_type }}</p>
+                    <input type="text" class="form-control" value="{{ user_type }}" readonly>
                 </div>
             </div>
 
             <!-- Submit button to save changes -->
-            <button type="submit" class="btn btn-primary btn-block mt-4">Save Changes</button>
+            <button type="submit" class="btn btn-save-changes btn-block mt-4">Save Changes</button>
         </form>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Ensure all account form fields use uniform width and show Company and User Type as read-only inputs
- Remove dark text override so labels display in white
- Add green "Save Changes" button with dark text

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689368bad1b88325a1f2fcbdb16cff8f