### PR TITLE
style: tighten account details layout and inputs

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -129,6 +129,17 @@ h6 {
     color: #192d38;
 }
 
+/* Account details form layout */
+.account-form {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* Read-only inputs styling */
+.form-control.readonly-field {
+  opacity: 0.6;
+}
+
 input[type="text"],
 input[type="password"],
 input[type="email"],

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/account_detail.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/account_detail.html
@@ -5,17 +5,17 @@
     <h2 class="text-center mb-4">Your Account Details</h2>
 
     <!-- Card for form layout with Bootstrap styling -->
-    <div class="card p-4 content-box mb-5">
+    <div class="card p-4 content-box mb-5 account-form">
         <form method="post" action="{% url 'accounts' %}">
             {% csrf_token %}
 
-            <!-- Display username as plaintext -->
+            <!-- Display username in a readonly input field -->
             <div class="row mb-3">
                 <div class="col-4 text-right">
                     <label>Username:</label>
                 </div>
                 <div class="col-8">
-                    <p class="form-control-plaintext">{{ user.username }}</p>
+                    <input type="text" class="form-control" value="{{ user.username }}" readonly>
                 </div>
             </div>
 
@@ -65,7 +65,7 @@
                     <label>Company:</label>
                 </div>
                 <div class="col-8">
-                    <input type="text" class="form-control" value="{{ fixed_company }}" readonly>
+                    <input type="text" class="form-control readonly-field" value="{{ fixed_company }}" readonly>
                 </div>
             </div>
 
@@ -95,12 +95,17 @@
                     <label>User Type:</label>
                 </div>
                 <div class="col-8">
-                    <input type="text" class="form-control" value="{{ user_type }}" readonly>
+                    <input type="text" class="form-control readonly-field" value="{{ user_type }}" readonly>
                 </div>
             </div>
 
             <!-- Submit button to save changes -->
-            <button type="submit" class="btn btn-save-changes btn-block mt-4">Save Changes</button>
+            <div class="row mt-4">
+                <div class="col-4"></div>
+                <div class="col-8">
+                    <button type="submit" class="btn btn-save-changes w-100">Save Changes</button>
+                </div>
+            </div>
         </form>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- center and narrow the account details card
- use a readonly input for username and greyed readonly styling for company and user type
- align save button with other fields

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68936b277bac83258c5378812d382ad3