### PR TITLE
Style launcher page buttons and welcome text

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -116,6 +116,34 @@ h6 {
     transform: scale(0.97);
 }
 
+/* Launcher page primary buttons */
+.launcher-btn {
+  background-color: #73D567;
+  color: #192d38;
+  border: none;
+  border-radius: 0.375rem;
+  padding: 2rem 1rem;
+  font-size: 1.5rem;
+  max-width: 350px;
+  width: 100%;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  transition: background-color 0.2s ease, transform 0.1s;
+}
+
+.launcher-btn:hover,
+.launcher-btn:focus {
+  background-color: #5ecb50;
+  color: #192d38;
+  text-decoration: none;
+}
+
+.launcher-btn:active {
+  transform: scale(0.97);
+  background-color: #4da73e;
+}
+
 /* Custom button for account save changes */
 .btn-save-changes {
     background-color: #73D567;

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
@@ -3,12 +3,12 @@
 
 {% block content %}
 {% if user.is_authenticated %}
-<h1 class="text-center mt-4" style="color: #192d38;">Welcome {{ user.username }}</h1>
+<h1 class="text-center mt-4 text-white">Welcome {{ user.username }}</h1>
 {% else %}
-<h1 class="text-center mt-4" style="color: #192d38;">Welcome</h1>
+<h1 class="text-center mt-4 text-white">Welcome</h1>
 {% endif %}
 
-<div class="container mt-4">
+<div class="container mt-4 text-center d-flex flex-column align-items-center">
     {% if notice %}
     <div class="card mb-4 mx-auto">
         <div class="card-body">
@@ -40,24 +40,12 @@
     </div>
     {% endif %}
 
-    <div class="row g-4 mt-2">
-        <div class="col-12 col-md-6 mb-4">
-            <a href="{% url 'home' %}" class="text-decoration-none">
-                <div class="card h-100">
-                    <div class="card-body d-flex flex-column justify-content-center align-items-center">
-                        <h2 class="card-title">Automation Tools</h2>
-                    </div>
-                </div>
-            </a>
+    <div class="row g-4 mt-2 justify-content-center">
+        <div class="col-12 col-md-6 mb-4 d-flex justify-content-center">
+            <a href="{% url 'home' %}" class="launcher-btn">Automation Tools</a>
         </div>
-        <div class="col-12 col-md-6 mb-4">
-            <a href="{% url 'equipment_dashboard' %}" class="text-decoration-none">
-                <div class="card h-100">
-                    <div class="card-body d-flex flex-column justify-content-center align-items-center">
-                        <h2 class="card-title">Equipment Booking</h2>
-                    </div>
-                </div>
-            </a>
+        <div class="col-12 col-md-6 mb-4 d-flex justify-content-center">
+            <a href="{% url 'equipment_dashboard' %}" class="launcher-btn">Equipment Booking</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Centered launcher page content and set welcome message to white for better readability.
- Added green (#73D567) buttons for Automation Tools and Equipment Booking with hover and active states.

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68936bcbdf2c83258652e1138be2ab5b