### PR TITLE
Refine green button hover colors and text contrast

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -133,14 +133,14 @@ h6 {
 
 .launcher-btn:hover,
 .launcher-btn:focus {
-  background-color: #5ecb50;
+  background-color: #05DA5B;
   color: #192d38;
   text-decoration: none;
 }
 
 .launcher-btn:active {
   transform: scale(0.97);
-  background-color: #4da73e;
+  background-color: #05C352;
 }
 
 /* Custom button for account save changes */
@@ -152,7 +152,12 @@ h6 {
 
 .btn-save-changes:hover,
 .btn-save-changes:focus {
-    background-color: #66c45b;
+    background-color: #05DA5B;
+    color: #192d38;
+}
+
+.btn-save-changes:active {
+    background-color: #05C352;
     color: #192d38;
 }
 
@@ -165,7 +170,12 @@ h6 {
 
 .btn-automation:hover,
 .btn-automation:focus {
-    background-color: #66c45b;
+    background-color: #05DA5B;
+    color: #192d38;
+}
+
+.btn-automation:active {
+    background-color: #05C352;
     color: #192d38;
 }
 


### PR DESCRIPTION
## Summary
- refine hover states for green buttons to use a closer shade to the base color
- standardize active states and ensure button text renders with dark #192d38 for readability

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689376bd4980832585cff7f5b266d5d4