### PR TITLE
Implement role-based controls for equipment booking

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
@@ -16,6 +16,9 @@
         <div class="col-12 col-sm-6 col-md-4 col-lg-3">
             <a href="{% url 'inbox' %}" class="btn btn-primary btn-lg w-100">Inbox</a>
         </div>
+        <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+            <a href="{% url 'user_accounts' %}" class="btn btn-primary btn-lg w-100">User Accounts</a>
+        </div>
         {% endif %}
         {% if user.is_staff %}
         <div class="col-12 col-sm-6 col-md-4 col-lg-3">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/inbox.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/inbox.html
@@ -44,8 +44,8 @@
 </div>
 
 <div class="container mt-5">
-    <h2 class="text-center mb-4">Unread Messages</h2>
-    {% if unread_messages %}
+    <h2 class="text-center mb-4">Unsettled Messages</h2>
+    {% if unsettled_messages %}
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
             <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
@@ -58,7 +58,7 @@
                 </tr>
             </thead>
             <tbody>
-                {% for msg in unread_messages %}
+                {% for msg in unsettled_messages %}
                 <tr class="text-center">
                     <td>{{ msg.sender.get_full_name|default:msg.sender.username }}</td>
                     <td>{{ msg.subject }}</td>
@@ -68,7 +68,7 @@
                         <a href="{% url 'message_detail' msg.id %}" class="btn btn-sm btn-primary mb-1">View</a>
                         <form method="post" class="d-inline">
                             {% csrf_token %}
-                            <button type="submit" name="mark_read" value="{{ msg.id }}" class="btn btn-sm btn-secondary">Mark as Read</button>
+                            <button type="submit" name="mark_replied" value="{{ msg.id }}" class="btn btn-sm btn-secondary">Mark Replied</button>
                         </form>
                     </td>
                 </tr>
@@ -83,7 +83,7 @@
 
 <div class="container mt-5">
     <h2 class="text-center mb-4">Settled Messages</h2>
-    {% if read_messages %}
+    {% if settled_messages %}
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
             <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
@@ -96,7 +96,7 @@
                 </tr>
             </thead>
             <tbody>
-                {% for msg in read_messages %}
+                {% for msg in settled_messages %}
                 <tr class="text-center">
                     <td>{{ msg.sender.get_full_name|default:msg.sender.username }}</td>
                     <td>{{ msg.subject }}</td>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
@@ -39,6 +39,10 @@
                 <i class="fas fa-inbox"></i>
                 <span class="sidebar-label">Inbox</span>
             </a>
+            <a href="{% url 'user_accounts' %}" class="nav-link" title="User Accounts" aria-label="User Accounts">
+                <i class="fas fa-users"></i>
+                <span class="sidebar-label">User Accounts</span>
+            </a>
             {% endif %}
             {% if user.is_staff %}
             <a href="{% url 'admin:index' %}" class="nav-link" title="Admin Tools" aria-label="Admin Tools">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/user_accounts.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/user_accounts.html
@@ -1,0 +1,33 @@
+{% extends 'workflow_automation/base.html' %}
+
+{% block content %}
+<div class="container mt-5">
+    <h2 class="text-center mb-4">User Accounts</h2>
+    <div class="table-responsive">
+        <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+                <tr class="text-center">
+                    <th>Username</th>
+                    <th>Email</th>
+                    <th>First Name</th>
+                    <th>Last Name</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for user in users %}
+                <tr class="text-center">
+                    <td>{{ user.username }}</td>
+                    <td>{{ user.email|default:'-' }}</td>
+                    <td>{{ user.first_name|default:'-' }}</td>
+                    <td>{{ user.last_name|default:'-' }}</td>
+                </tr>
+                {% empty %}
+                <tr>
+                    <td colspan="4" class="text-center">No users found.</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -445,3 +445,19 @@ class MessageResponseTests(TestCase):
         response = self.client.get(reverse("user_messages"))
         self.assertContains(response, "Done")
 
+
+class UserAccountsAccessTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="ua_user", password="pass")
+        self.admin = User.objects.create_user(username="ua_admin", password="pass", is_superuser=True)
+
+    def test_superuser_can_view_accounts(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(reverse("user_accounts"))
+        self.assertContains(response, self.user.username)
+
+    def test_regular_user_forbidden(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("user_accounts"))
+        self.assertEqual(response.status_code, 403)
+

--- a/equipment_booking_app/workflow_automation/urls.py
+++ b/equipment_booking_app/workflow_automation/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     path('create-booking/', views.create_booking, name='create_booking'),
     path('previous-bookings/', views.previous_bookings, name='previous_bookings'),
     path('my-bookings/', views.booking_list, name='my_bookings'),
+    path('accounts/all/', views.user_accounts, name='user_accounts'),
     path('inbox/', views.inbox, name='inbox'),
     path('messages/', views.user_messages, name='user_messages'),
     path('manage-notice/', views.manage_notice, name='manage_notice'),

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -313,6 +313,14 @@ def previous_bookings(request):
 
 
 @login_required
+def user_accounts(request):
+    if not request.user.is_superuser:
+        return HttpResponseForbidden("You are not allowed to view this page.")
+    users = User.objects.all().select_related('profile')
+    return render(request, 'workflow_automation/user_accounts.html', {'users': users})
+
+
+@login_required
 def contact(request):
     if not request.user.email:
         messages.error(request, 'You need an active email associated with your account to send a message.')
@@ -355,12 +363,12 @@ def user_messages(request):
 @user_passes_test(lambda u: u.is_superuser)
 def inbox(request):
     pending_workflows = Workflow.objects.filter(awaiting_review=True).select_related('created_by')
-    unread_messages = (
+    unsettled_messages = (
         Message.objects.filter(recipient=request.user, is_review_request=False, is_read=False)
         .select_related('sender')
         .order_by('-created_at')
     )
-    read_messages = (
+    settled_messages = (
         Message.objects.filter(recipient=request.user, is_review_request=False, is_read=True)
         .select_related('sender')
         .order_by('-created_at')
@@ -404,8 +412,8 @@ def inbox(request):
             )
             messages.success(request, 'Workflow rejected.')
             return redirect('inbox')
-        if 'mark_read' in request.POST:
-            msg_id = request.POST.get('mark_read')
+        if 'mark_replied' in request.POST:
+            msg_id = request.POST.get('mark_replied')
             msg = get_object_or_404(Message, id=msg_id, recipient=request.user)
             msg.is_read = True
             msg.save()
@@ -416,8 +424,8 @@ def inbox(request):
         'workflow_automation/inbox.html',
         {
             'pending_workflows': pending_workflows,
-            'unread_messages': unread_messages,
-            'read_messages': read_messages,
+            'unsettled_messages': unsettled_messages,
+            'settled_messages': settled_messages,
         },
     )
 


### PR DESCRIPTION
## Summary
- Add admin-only user accounts view and navigation links
- Show inbox sections for unsettled vs settled messages and allow marking replies
- Test user account access restrictions

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68946fdf0f348325923d0d4bf71acd78