### PR TITLE
Require login for home page

### DIFF
--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -461,3 +461,10 @@ class UserAccountsAccessTests(TestCase):
         response = self.client.get(reverse("user_accounts"))
         self.assertEqual(response.status_code, 403)
 
+
+class LauncherAccessTests(TestCase):
+    def test_launcher_requires_login(self):
+        response = self.client.get(reverse("launcher"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse("login"), response.url)
+

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -57,6 +57,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth import authenticate, login, logout
 
 
+@login_required
 def launcher(request):
     """Render the root landing page with message board and section links."""
     notice = Notice.objects.last()


### PR DESCRIPTION
## Summary
- Protect root launcher view with `@login_required`
- Test that unauthenticated users are redirected to login

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689478ce93e083258b115fe7c24f2fff