### PR TITLE
Improve contact form readability

### DIFF
--- a/equipment_booking_app/workflow_automation/forms.py
+++ b/equipment_booking_app/workflow_automation/forms.py
@@ -67,14 +67,22 @@ class ProfileForm(forms.ModelForm):
 
 
 class MessageForm(forms.ModelForm):
-    workflow = forms.ModelChoiceField(queryset=Workflow.objects.none(), required=False)
+    workflow = forms.ModelChoiceField(
+        queryset=Workflow.objects.none(),
+        required=False,
+        widget=forms.Select(attrs={"class": "form-control w-100"}),
+    )
 
     class Meta:
         model = Message
-        fields = ['subject', 'content', 'workflow']
+        fields = ["subject", "content", "workflow"]
         widgets = {
-            'subject': forms.TextInput(attrs={'placeholder': 'Enter subject here...'}),
-            'content': forms.Textarea(attrs={'placeholder': 'Type your message here...'}),
+            "subject": forms.TextInput(
+                attrs={"placeholder": "Enter subject here...", "class": "form-control w-100"}
+            ),
+            "content": forms.Textarea(
+                attrs={"placeholder": "Type your message here...", "class": "form-control w-100"}
+            ),
         }
 
     def __init__(self, *args, **kwargs):

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/contact.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/contact.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">Submit Question or Workflow</h2>
 
     <!-- Card for styling the content, similar to booking form design -->
-    <div class="card p-4 content-box mb-5" style="color: #192d38;">
+    <div class="card p-4 content-box mb-5" style="color: #fff;">
         
         <!-- Check if the user is authenticated -->
         {% if user.is_authenticated %}
@@ -54,7 +54,7 @@
 
                     <!-- Submit button centered -->
                     <div class="d-flex justify-content-center">
-                        <button type="submit" class="btn btn-primary mt-4">Send Message</button>
+                        <button type="submit" class="btn btn-automation mt-4">Send Message</button>
                     </div>
                 </form>
             


### PR DESCRIPTION
## Summary
- make contact form text white and use site's green accent for submit button
- ensure subject, message, and workflow inputs share consistent width

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68947e282b448325b4e0dd7a2b76da00