### PR TITLE
Enable page scrolling and remove extra bottom padding

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -25,7 +25,8 @@
 html,
 body {
   height: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 body {
@@ -40,6 +41,7 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  padding-bottom: 0;
 }
 
 a,
@@ -59,7 +61,8 @@ main {
   flex-direction: column;
   align-items: center;
   text-align: center;
-  overflow: hidden;
+  overflow-y: auto;
+  padding-bottom: 0;
 }
 
 h1,
@@ -345,4 +348,6 @@ footer {
   max-width: 900px;
   margin-left: auto;
   margin-right: auto;
+  max-height: 80vh;
+  overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- Allow vertical scrolling by replacing global hidden overflow with `overflow-y: auto` and clearing bottom padding
- Make main content area and content boxes scrollable with `max-height`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6894cadcc9c483259ea6e6fe6d4758ef