### PR TITLE
Fix read-only account input styling

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -194,8 +194,10 @@ h6 {
 }
 
 /* Read-only inputs styling */
-.form-control.readonly-field {
-  opacity: 0.6;
+.form-control[readonly] {
+  background-color: #122231;
+  color: var(--text-color);
+  padding: 0.5rem;
 }
 
 input[type="text"],


### PR DESCRIPTION
## Summary
- Restyle read-only account inputs with dark #122231 background and consistent text color
- Reduce left padding to remove excessive gap in account form fields

## Testing
- `python equipment_booking_app/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6898cd88418c83258c633d1954127a6a