### PR TITLE
Use POST for previous bookings form

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/booking_list.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/booking_list.html
@@ -105,7 +105,7 @@
 
     <!-- Button to view all previous bookings -->
     <div class="text-center mt-4 mb-5"> <!-- Add space between content and footer -->
-        <form action="{% url 'previous_bookings' %}" method="get" style="display:inline;">
+        <form action="{% url 'previous_bookings' %}" method="post" style="display:inline;">
             {% csrf_token %}
             <button type="submit" class="btn btn-primary">View All Previous Bookings</button>
         </form>


### PR DESCRIPTION
## Summary
- switch previous bookings button form to POST so the CSRF token is sent in the request body instead of the URL

## Testing
- `python equipment_booking_app/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6898d81541ec83258d33f4dcbfbdecd9