### PR TITLE
Ensure readable table text

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -288,7 +288,7 @@ select:focus {
 }
 
 .table {
-  color: var(--text-color);
+  color: #192d38;
 }
 
 .sidebar {

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/booking_list.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/booking_list.html
@@ -14,7 +14,7 @@
     <!-- Responsive table for displaying upcoming bookings -->
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); font-size: 1.25rem; text-align: center;">
                 <tr class="text-center">
                     {% if is_superuser %}
                         <th>User</th> 
@@ -72,7 +72,7 @@
     <h2 class="text-center mb-4 mt-5">Previous Bookings</h2>
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;"> <!-- Table header for previous bookings -->
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); font-size: 1.25rem; text-align: center;"> <!-- Table header for previous bookings -->
                 <tr class="text-center">
                     {% if is_superuser %}
                         <th>User</th> <!-- Display user for superusers -->

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/inbox.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/inbox.html
@@ -6,7 +6,7 @@
     {% if pending_workflows %}
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); font-size: 1.25rem; text-align: center;">
                 <tr class="text-center">
                     <th>Workflow</th>
                     <th>Submitted By</th>
@@ -48,7 +48,7 @@
     {% if unsettled_messages %}
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); font-size: 1.25rem; text-align: center;">
                 <tr class="text-center">
                     <th>Sender</th>
                     <th>Subject</th>
@@ -86,7 +86,7 @@
     {% if settled_messages %}
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); font-size: 1.25rem; text-align: center;">
                 <tr class="text-center">
                     <th>Sender</th>
                     <th>Subject</th>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/my_workflows.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/my_workflows.html
@@ -14,7 +14,7 @@
 </div>
 <div class="table-responsive mb-5">
 <table id="my-workflows" class="table table-striped table-bordered table-hover w-100" style="background-color:#ffffff; width:100%;">
-<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:#192d38; text-align:center;">
+<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); text-align:center;">
 <tr><th>Name</th><th>Status</th><th>Actions</th></tr>
 </thead>
 <tbody>
@@ -67,7 +67,7 @@
 <h3 class="text-center mb-4">Imported Workflows</h3>
 <div class="table-responsive">
 <table class="table table-striped table-bordered table-hover w-100" style="background-color:#ffffff; width:100%;">
-<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:#192d38; text-align:center;">
+<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); text-align:center;">
 <tr><th>Name</th><th>Source</th><th>Status</th><th>Actions</th></tr>
 </thead>
 <tbody>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/previous_bookings.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/previous_bookings.html
@@ -6,7 +6,7 @@
 
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); font-size: 1.25rem; text-align: center;">
                 <!-- Table headers for user, item, start time, and end time -->
                 <tr class="text-center">
                     <th>User</th>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/shared_workflows.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/shared_workflows.html
@@ -10,7 +10,7 @@
 
 <div class="table-responsive">
 <table class="table table-striped table-bordered table-hover w-100" style="background-color:#ffffff; width:100%;">
-<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:#192d38; text-align:center;">
+<thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); text-align:center;">
 <tr><th>Name</th><th>Description</th><th>Author</th><th>Actions</th></tr>
 </thead>
 <tbody>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/user_accounts.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/user_accounts.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">User Accounts</h2>
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color: #192d38; font-size: 1.25rem; text-align: center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); font-size: 1.25rem; text-align: center;">
                 <tr class="text-center">
                     <th>Username</th>
                     <th>Email</th>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
@@ -6,7 +6,7 @@
     {% if user_messages %}
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width:100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:#192d38; font-size:1.25rem; text-align:center;">
+            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); font-size:1.25rem; text-align:center;">
                 <tr class="text-center">
                     <th>Subject</th>
                     <th>Date Sent</th>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_dashboard.html
@@ -24,7 +24,7 @@
 {% elif recent_runs %}
     <div class="table-responsive">
     <table class="table table-striped table-bordered table-hover w-100" style="background-color:#ffffff;">
-        <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); color:#192d38; text-align:center;">
+        <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); text-align:center;">
             <tr><th>Name</th><th>Last Used</th><th>Actions</th></tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Summary
- set `.table` text color to `#192d38` for consistent dark text
- remove redundant inline color styles from table headers

## Testing
- `python3 manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6898d93edd74832582d070994c019e74