### PR TITLE
Remove Response column from user messages page

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
@@ -11,7 +11,6 @@
                     <th>Subject</th>
                     <th>Date Sent</th>
                     <th>Message</th>
-                    <th>Response</th>
                 </tr>
             </thead>
             <tbody>
@@ -20,7 +19,6 @@
                     <td>{{ msg.subject }}</td>
                     <td>{{ msg.created_at }}</td>
                     <td>{{ msg.content|linebreaks }}</td>
-                    <td>{{ msg.response|default:'No response yet'|linebreaks }}</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -436,14 +436,14 @@ class MessageResponseTests(TestCase):
         self.assertTrue(self.msg.is_read)
         self.assertRedirects(response, reverse("inbox"))
 
-    def test_user_can_view_response(self):
+    def test_user_messages_page_excludes_response(self):
         self.msg.response = "Done"
         self.msg.responded_by = self.admin
         self.msg.is_read = True
         self.msg.save()
         self.client.force_login(self.user)
         response = self.client.get(reverse("user_messages"))
-        self.assertContains(response, "Done")
+        self.assertNotContains(response, "Done")
 
 
 class UserAccountsAccessTests(TestCase):


### PR DESCRIPTION
## Summary
- Remove unnecessary Response column from user messages table
- Update tests to verify the page no longer shows message responses

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6898dbe55f808325998d533bb6a5e181