### PR TITLE
Add previous messages and bookings buttons

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
@@ -8,12 +8,18 @@
         <h4 class="text-center mb-4">Welcome {{ user.username }}</h4>
 
         <div class="container">
-            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 g-3 mb-4 text-center">
+            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-2 row-cols-lg-4 g-3 mb-4 text-center justify-content-center">
                 <div class="col d-flex">
                     <a href="{% url 'create_booking' %}" class="btn btn-automation btn-lg flex-fill">Create Booking</a>
                 </div>
                 <div class="col d-flex">
                     <a href="{% url 'my_bookings' %}" class="btn btn-automation btn-lg flex-fill">My Bookings</a>
+                </div>
+                <div class="col d-flex">
+                    <a href="{% url 'user_messages' %}" class="btn btn-automation btn-lg flex-fill">Previous Messages</a>
+                </div>
+                <div class="col d-flex">
+                    <a href="{% url 'previous_bookings' %}" class="btn btn-automation btn-lg flex-fill">Previous Bookings</a>
                 </div>
                 {% if user.is_superuser %}
                 <div class="col d-flex">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="container mt-5">
-    <h2 class="text-center mb-4">My Messages</h2>
+    <h2 class="text-center mb-4">Previous Messages</h2>
     {% if user_messages %}
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width:100%;">

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -347,7 +347,10 @@ def contact(request):
     return render(request, 'workflow_automation/contact.html', {'form': form})
 @login_required
 def user_messages(request):
-    msgs = Message.objects.filter(sender=request.user).order_by('-created_at')
+    msgs = (
+        Message.objects.filter(sender=request.user, workflow__isnull=True)
+        .order_by('-created_at')
+    )
     return render(request, 'workflow_automation/user_messages.html', {'user_messages': msgs})
 
 @user_passes_test(lambda u: u.is_superuser)


### PR DESCRIPTION
## Summary
- Show additional options on equipment dashboard for viewing previous messages and previous bookings
- Filter user messages to exclude ones linked to workflows
- Update messages page header to "Previous Messages"

## Testing
- `python manage.py test workflow_automation`


------
https://chatgpt.com/codex/tasks/task_e_6898dc5c001483258f2de89ff790e5a3