### PR TITLE
Increase badge label font size

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -44,6 +44,11 @@ body {
   padding-bottom: 0;
 }
 
+.badge {
+  font-size: 14.4px;
+  font-family: "Bienvenue", sans-serif;
+}
+
 a,
 a:visited {
   color: var(--text-color);


### PR DESCRIPTION
## Summary
- enlarge workflow status badges to 14.4px
- apply Bienvenue font to badge labels for visual consistency

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6898dedaf6248325b256d1c3a954d526