### PR TITLE
Simplify workflow status display

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/my_workflows.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/my_workflows.html
@@ -21,17 +21,7 @@
 {% for wf in my_workflows %}
 <tr class="text-center" data-status="{{ wf.status_category }}">
     <td>{{ wf.obj.name }} <span class="badge bg-success">mine</span></td>
-    <td>
-        {% if wf.status_category == 'Published' %}
-            <span class="badge bg-success">Published: Yes</span>
-        {% elif wf.status_category == 'Awaiting Review' %}
-            <span class="badge bg-info text-dark">Status: Awaiting Review</span>
-        {% elif wf.status_category == 'Rejected' %}
-            <span class="badge bg-danger">{{ wf.status_text }}</span>
-        {% else %}
-            <span class="badge bg-secondary">Published: No</span>
-        {% endif %}
-    </td>
+    <td>{{ wf.status_text }}</td>
     <td>
         {% if wf.status_category == 'Unpublished' or wf.status_category == 'Rejected' %}
         <form method="post" action="{% url 'request_review' wf.obj.id %}" class="d-inline">
@@ -75,13 +65,7 @@
 <tr class="text-center">
     <td>{{ wf.obj.name }} <span class="badge bg-secondary">shared</span></td>
     <td>{% if wf.obj.source_creator %}{{ wf.obj.source_creator.username }}{% else %}Shared{% endif %}</td>
-    <td>
-        {% if wf.status_category == 'Published' %}
-            <span class="badge bg-success">Published: Yes</span>
-        {% else %}
-            <span class="badge bg-secondary">Published: No</span>
-        {% endif %}
-    </td>
+    <td>{{ wf.status_text }}</td>
     <td>
         <a href="{% url 'run_workflow_specific' wf.obj.id %}" class="btn btn-sm btn-success">Run Workflow</a>
         <form method="POST" action="{% url 'delete_workflow' wf.obj.id %}" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this workflow?')">

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -600,17 +600,17 @@ def my_workflows(request):
         items = []
         for wf in queryset:
             if wf.review_status == "pending":
-                status_text = "Status: Awaiting Review"
+                status_text = "Awaiting Review"
                 category = "Awaiting Review"
             elif wf.review_status == "rejected":
                 comment = wf.rejection_comment if wf.created_by_id == request.user.id else ""
-                status_text = f"Status: Rejected" + (f" - {comment}" if comment else "")
+                status_text = "Rejected" + (f" - {comment}" if comment else "")
                 category = "Rejected"
             elif wf.review_status == "accepted" or wf.is_published or imported:
-                status_text = "Published: Yes"
+                status_text = "Published"
                 category = "Published"
             else:
-                status_text = "Published: No"
+                status_text = "Unpublished"
                 category = "Unpublished"
             items.append({"obj": wf, "status_text": status_text, "status_category": category})
         return items


### PR DESCRIPTION
## Summary
- Display workflow statuses as plain text on My Workflows page
- Keep mine/shared badges while removing status labels
- Simplify build_items helper to generate user-friendly status text

## Testing
- `pytest`
- `python equipment_booking_app/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6898e0bc94a48325b68195d705cbe614