### PR TITLE
Align launcher buttons side by side

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
@@ -40,11 +40,11 @@
     </div>
     {% endif %}
 
-    <div class="row g-4 mt-2 content-box">
-        <div class="col-12 mb-4">
+    <div class="row g-2 mt-2 mb-4 content-box">
+        <div class="col-6">
             <a href="{% url 'home' %}" class="launcher-btn">Automation Tools</a>
         </div>
-        <div class="col-12 mb-4">
+        <div class="col-6">
             <a href="{% url 'equipment_dashboard' %}" class="launcher-btn">Equipment Booking</a>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Align Automation Tools and Equipment Booking buttons horizontally with small gap.

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6898e271b358832592d11d5c35225dea