### PR TITLE
Allow superusers to post notice board messages

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
@@ -14,11 +14,22 @@
                     <h5 class="card-title">Message Board</h5>
                     <p class="card-text">{{ notice.message }}</p>
                     {% if user.is_superuser %}
-                    <form method="post" action="{% url 'remove_notice' %}" onsubmit="return confirm('Delete this notice?');">
-                        {% csrf_token %}
-                        <button type="submit" class="btn btn-danger">Remove Notice</button>
-                    </form>
+                    <div class="d-flex gap-2">
+                        <a href="{% url 'manage_notice' %}" class="btn btn-primary">New Notice</a>
+                        <form method="post" action="{% url 'remove_notice' %}" onsubmit="return confirm('Delete this notice?');">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-danger">Remove Notice</button>
+                        </form>
+                    </div>
                     {% endif %}
+                </div>
+            </div>
+            {% elif user.is_superuser %}
+            <div class="card mb-4">
+                <div class="card-body">
+                    <h5 class="card-title">Message Board</h5>
+                    <p class="card-text">No notice posted.</p>
+                    <a href="{% url 'manage_notice' %}" class="btn btn-primary">Create Notice</a>
                 </div>
             </div>
             {% endif %}
@@ -36,4 +47,3 @@
     {% endif %}
 </section>
 {% endblock %}
-

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/manage_notice.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/manage_notice.html
@@ -1,0 +1,13 @@
+{% extends 'workflow_automation/base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Notice Board</h2>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" class="btn btn-primary">Save Notice</button>
+        <a href="{% url 'launcher' %}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Show "New Notice" button to superusers on launcher page and allow creation when no notice exists
- Add dedicated template for editing notice board messages

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6898e66c1b9c83259d795aa8919d6b71