### PR TITLE
Hide contact button for superusers

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_automation.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_automation.html
@@ -30,10 +30,12 @@
                 <i class="fas fa-share-alt"></i>
                 <span class="sidebar-label">Shared Workflows</span>
             </a>
+            {% if not user.is_superuser %}
             <a href="{% url 'contact' %}" class="nav-link" title="Contact" aria-label="Contact">
                 <i class="fas fa-envelope"></i>
                 <span class="sidebar-label">Contact</span>
             </a>
+            {% endif %}
             {% if user.is_superuser %}
             <a href="{% url 'review_workflows' %}" class="nav-link" title="Review Requests" aria-label="Review Requests">
                 <i class="fas fa-check-circle"></i>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
@@ -26,10 +26,12 @@
                 <i class="fas fa-history"></i>
                 <span class="sidebar-label">Previous Bookings</span>
             </a>
+            {% if not user.is_superuser %}
             <a href="{% url 'contact' %}" class="nav-link" title="Contact" aria-label="Contact">
                 <i class="fas fa-envelope"></i>
                 <span class="sidebar-label">Contact</span>
             </a>
+            {% endif %}
             <a href="{% url 'user_messages' %}" class="nav-link" title="My Messages" aria-label="My Messages">
                 <i class="fas fa-envelope-open"></i>
                 <span class="sidebar-label">My Messages</span>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_launcher.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_launcher.html
@@ -36,10 +36,12 @@
                 <i class="fas fa-share-alt"></i>
                 <span class="sidebar-label">Shared Workflows</span>
             </a>
+            {% if not user.is_superuser %}
             <a href="{% url 'contact' %}" class="nav-link" title="Contact" aria-label="Contact">
                 <i class="fas fa-envelope"></i>
                 <span class="sidebar-label">Contact</span>
             </a>
+            {% endif %}
             <hr>
             <span class="text-light px-3">Account</span>
             <a href="{% url 'accounts' %}" class="nav-link" title="Profile" aria-label="Profile">

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -364,11 +364,11 @@ class SidebarLinksTests(TestCase):
         self.assertContains(response, reverse("contact"))
         self.assertNotContains(response, reverse("inbox"))
 
-    def test_contact_and_inbox_visible_for_superuser(self):
+    def test_inbox_visible_but_contact_hidden_for_superuser(self):
         self.client.force_login(self.admin)
         response = self.client.get(reverse("home"))
         self.assertContains(response, reverse("inbox"))
-        self.assertContains(response, reverse("contact"))
+        self.assertNotContains(response, reverse("contact"))
 
 
 class ContactPageTests(TestCase):


### PR DESCRIPTION
## Summary
- Hide Contact navigation link for superusers across all sidebars
- Update sidebar link tests to expect Contact hidden for superusers

## Testing
- `python manage.py test workflow_automation.tests.SidebarLinksTests workflow_automation.tests.ContactPageTests -v 2`
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6898e6d8845c832592ef109b18192e15