### PR TITLE
Add demo workflow simulation

### DIFF
--- a/equipment_booking_app/workflow_automation/static/js/demo_workflow.js
+++ b/equipment_booking_app/workflow_automation/static/js/demo_workflow.js
@@ -1,0 +1,56 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const demoBtn = document.getElementById('demo-btn');
+  if (!demoBtn) return;
+
+  const container = document.getElementById('demo-container');
+  const bar = document.getElementById('demo-progress-bar');
+  const action = document.getElementById('demo-current-action');
+  const logList = document.getElementById('demo-log');
+  const complete = document.getElementById('demo-complete');
+
+  demoBtn.addEventListener('click', () => {
+    container.classList.remove('d-none');
+    bar.classList.remove('bg-success');
+    bar.style.width = '0%';
+    bar.textContent = '0%';
+    action.textContent = '';
+    logList.innerHTML = '';
+    complete.classList.add('d-none');
+
+    const steps = [
+      { time: 0, text: 'Starting demo workflow...' },
+      { time: 10, text: 'Reading input files...' },
+      { time: 20, text: 'Processing data...' },
+      { time: 40, text: 'Finalising...' },
+      { time: 60, text: 'Demo complete.' }
+    ];
+
+    let stepIndex = 0;
+    const total = 60; // seconds
+    let elapsed = 0;
+
+    const timer = setInterval(() => {
+      elapsed++;
+      const percent = Math.min(100, Math.floor((elapsed / total) * 100));
+      bar.style.width = percent + '%';
+      bar.textContent = percent + '%';
+
+      if (stepIndex < steps.length && elapsed >= steps[stepIndex].time) {
+        const msg = steps[stepIndex].text;
+        action.textContent = msg;
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.textContent = msg;
+        logList.appendChild(li);
+        stepIndex++;
+      }
+
+      if (elapsed >= total) {
+        clearInterval(timer);
+        bar.classList.add('bg-success');
+        complete.classList.remove('d-none');
+      }
+    }, 1000);
+  });
+});
+

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
@@ -26,7 +26,21 @@
                 <div class="col d-flex">
                     <a href="{% url 'shared_workflows' %}" class="btn btn-automation btn-lg flex-fill">Shared Workflows</a>
                 </div>
+                <div class="col d-flex">
+                    <button id="demo-btn" class="btn btn-secondary btn-lg flex-fill">Demo Workflow</button>
+                </div>
             </div>
+
+            <div id="demo-container" class="content-box mt-4 d-none" style="color:#192d38;">
+                <div class="progress mb-3">
+                    <div id="demo-progress-bar" class="progress-bar" role="progressbar" style="width:0%">0%</div>
+                </div>
+                <p id="demo-current-action" class="mb-3"></p>
+                <ul id="demo-log" class="list-group mb-3"></ul>
+                <div id="demo-complete" class="alert alert-success d-none">Demo complete</div>
+            </div>
+
+            <script src="{% static 'js/demo_workflow.js' %}"></script>
         </div>
     {% else %}
         <p class="text-center">Welcome to the AtkinsRéalis Equipment Booking App!</p>


### PR DESCRIPTION
## Summary
- add Demo Workflow button on dashboard
- simulate 60-second progress with log messages for UI preview

## Testing
- `python manage.py test` *(fails: KeyboardInterrupt in workflow_automation/tests.py:139)*

------
https://chatgpt.com/codex/tasks/task_e_6899f6a70470832593686b29b3538836