### PR TITLE
Use ffprobe midpoint for video previews

### DIFF
--- a/equipment_booking_app/workflow_automation/file_utils.py
+++ b/equipment_booking_app/workflow_automation/file_utils.py
@@ -124,15 +124,27 @@ def trim_video(src: str, dst: str, start: int, end: int) -> str:
 
 
 def generate_video_preview(src: str, dst: str) -> str:
-    """Create a single preview frame from ``src`` using ffmpeg."""
+    """Create a single preview frame from ``src`` using ffmpeg.
+
+    The frame is taken from the video's midpoint as reported by ``ffprobe``.
+    If ``ffprobe`` is unavailable or fails, a frame from the 2-second mark is
+    used instead.
+    """
     if ffmpeg_exists():
+        timestamp = "00:00:02"
+        duration = get_video_duration(src)
+        if duration > 0:
+            midpoint = duration / 2
+            hours, remainder = divmod(midpoint, 3600)
+            minutes, seconds = divmod(remainder, 60)
+            timestamp = f"{int(hours):02d}:{int(minutes):02d}:{seconds:06.3f}"
         cmd = [
             "ffmpeg",
             "-y",
             "-i",
             src,
             "-ss",
-            "00:00:02",
+            timestamp,
             "-frames:v",
             "1",
             dst,

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -15,6 +15,7 @@ from . import file_utils, views
 from .log_writer import write_workflow_log
 from types import SimpleNamespace
 from unittest.mock import patch
+import subprocess
 import shutil
 import tempfile
 from datetime import datetime
@@ -47,6 +48,33 @@ class FileUtilsTests(TestCase):
             self.assertEqual(len(paths), 1)
             self.assertTrue(paths[0].startswith(os.path.join(out_root, "SITE")))
             self.assertTrue(os.path.exists(paths[0] + ".convert"))
+
+
+    @patch("workflow_automation.file_utils.ffmpeg_exists", return_value=True)
+    @patch("workflow_automation.file_utils.subprocess.run")
+    @patch("workflow_automation.file_utils.subprocess.check_output")
+    def test_generate_video_preview_midpoint(
+        self, mock_check_output, mock_run, mock_exists
+    ):
+        mock_check_output.return_value = b"10.0"
+        file_utils.generate_video_preview("in.mp4", "out.jpg")
+        cmd = mock_run.call_args[0][0]
+        ss_val = cmd[cmd.index("-ss") + 1]
+        self.assertEqual(ss_val, "00:00:05.000")
+
+    @patch("workflow_automation.file_utils.ffmpeg_exists", return_value=True)
+    @patch("workflow_automation.file_utils.subprocess.run")
+    @patch(
+        "workflow_automation.file_utils.subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(1, "ffprobe"),
+    )
+    def test_generate_video_preview_ffprobe_failure(
+        self, mock_check_output, mock_run, mock_exists
+    ):
+        file_utils.generate_video_preview("in.mp4", "out.jpg")
+        cmd = mock_run.call_args[0][0]
+        ss_val = cmd[cmd.index("-ss") + 1]
+        self.assertEqual(ss_val, "00:00:02")
 
 
 class WorkflowMatchTests(TestCase):


### PR DESCRIPTION
## Summary
- capture video preview frame from the midpoint using ffprobe
- document new behavior and add tests for midpoint and ffprobe failures

## Testing
- `python equipment_booking_app/manage.py test workflow_automation 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689b0a1f1500832587417107374070b0