### PR TITLE
Prefill read-only initials in workflow run

### DIFF
--- a/equipment_booking_app/workflow_automation/forms.py
+++ b/equipment_booking_app/workflow_automation/forms.py
@@ -175,16 +175,31 @@ class RunWorkflowForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        user = kwargs.pop("user", None)
+        self.user = kwargs.pop("user", None)
         wf_qs = kwargs.pop("workflow_queryset", None)
         super().__init__(*args, **kwargs)
+
         if wf_qs is not None:
             self.fields["workflow"].queryset = wf_qs
-        elif user:
-            self.fields["workflow"].queryset = Workflow.objects.filter(created_by=user)
-            profile = Profile.objects.filter(user=user).first()
+        elif self.user:
+            self.fields["workflow"].queryset = Workflow.objects.filter(created_by=self.user)
+
+        if self.user:
+            profile = Profile.objects.filter(user=self.user).first()
             if profile and profile.initials:
                 self.fields["initials"].initial = profile.initials
+                self.fields["initials"].widget.attrs["readonly"] = True
+                existing = self.fields["initials"].widget.attrs.get("class", "")
+                self.fields["initials"].widget.attrs["class"] = (
+                    existing + " form-control"
+                ).strip()
+
+    def clean_initials(self):
+        if self.user:
+            profile = Profile.objects.filter(user=self.user).first()
+            if profile and profile.initials:
+                return profile.initials
+        return self.cleaned_data.get("initials", "")
 
     def clean(self):
         cleaned = super().clean()

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -11,6 +11,7 @@ from django.contrib.messages import get_messages
 from django.urls import reverse
 from .models import Workflow, Profile, Message
 from .workflow_runner import WorkflowRunner
+from .forms import RunWorkflowForm
 from . import file_utils, views
 from .log_writer import write_workflow_log
 from types import SimpleNamespace
@@ -108,6 +109,31 @@ class RunWorkflowNoMatchTests(TestCase):
         response = self.client.post(reverse("run_workflow"), data)
         messages = list(get_messages(response.wsgi_request))
         self.assertTrue(any("No workflow matched" in str(m) for m in messages))
+
+
+class RunWorkflowInitialsTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="runner2", password="pass")
+        Profile.objects.create(user=self.user, initials="AB")
+        self.wf = Workflow.objects.create(name="MyFlow", created_by=self.user)
+
+    def test_initials_from_profile_and_readonly(self):
+        form = RunWorkflowForm(
+            data={
+                "workflow": self.wf.id,
+                "input_path": "/tmp/foo",
+                "use_input_path": "True",
+                "output_path": "/tmp/foo",
+                "project_code": "",
+                "initials": "ZZ",
+                "pause_between_steps": False,
+            },
+            user=self.user,
+            workflow_queryset=Workflow.objects.filter(created_by=self.user),
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["initials"], "AB")
+        self.assertIn("readonly", form.fields["initials"].widget.attrs)
 
 
 class GenerateNextFilenameTests(TestCase):


### PR DESCRIPTION
## Summary
- Prefill run workflow initials from the user's profile and render them as read-only inputs
- Ensure form always trusts profile initials server-side
- Add test to verify initials field behavior

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689d9b30c8908325b2797da946781513