### PR TITLE
Standardize top spacing

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -68,6 +68,12 @@ main {
   text-align: center;
   overflow-y: auto;
   padding-bottom: 0;
+  padding-top: 2rem;
+}
+
+/* Ensure top spacing across all pages regardless of Bootstrap defaults */
+main.container {
+  padding-top: 2rem;
 }
 
 h1,

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/account_detail.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/account_detail.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
   <h2 class="text-center mb-4">Your Account Details</h2>
 
   <!-- Scrolls inside the card only (uses global .scroll-y from base) -->

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/admin.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/admin.html
@@ -1,9 +1,9 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5 text-center">
+<div class="container text-center">
     <h2 style="color: #ffffff;">Access Notice</h2>
-    <p class="mt-4" style="font-size: 1.2rem; color: white;">
+    <p style="font-size: 1.2rem; color: white;">
         This area is secured and does not provide direct access through this URL.<br>
     
         This site undergoes regular security audits in line with OWASP Top 10 best practices.

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/booking_list.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/booking_list.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
     <!-- Display different title based on whether the user is a superuser -->
     <h2 class="text-center mb-4">
         {% if is_superuser %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/contact.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/contact.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
   <h2 class="text-center mb-4">Submit Question or Workflow</h2>
 
   <!-- Scrolls internally; page itself does not scroll -->

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/create_booking.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/create_booking.html
@@ -56,7 +56,7 @@
   }
 </style>
 
-<div class="container mt-5">
+<div class="container">
   <h2 class="text-center mb-4">Create Booking</h2>
 
   <div class="card p-4 content-box mb-5 account-form">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/create_workflow.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/create_workflow.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
   {% if workflow %}
     <h2 class="text-center mb-4">Edit Workflow</h2>
   {% else %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/edit_booking.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/edit_booking.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
     <h2 class="text-center mb-4">Edit Booking</h2>
 
     <!-- Box around the form (Bootstrap card) with a white background and text color adjusted -->

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
@@ -1,9 +1,9 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<h1 class="text-center mt-4">Equipment Booking Dashboard</h1>
+<h1 class="text-center">Equipment Booking Dashboard</h1>
 
-<section class="mt-4">
+<section>
     {% if user.is_authenticated %}
         <h4 class="text-center mb-4">Welcome {{ user.username }}</h4>
 

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block content %}
-<h1 class="text-center mt-4">Automation Dashboard</h1>
+<h1 class="text-center">Automation Dashboard</h1>
 
 <style>
   /* Polished green CTA buttons */
@@ -31,7 +31,7 @@
   .btn-automation.btn-lg{ padding-top:.9rem; padding-bottom:.9rem; }
 </style>
 
-<section class="mt-4">
+<section>
   {% if user.is_authenticated %}
     <h4 class="text-center mb-4">Welcome {{ user.username }}</h4>
 

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/launcher.html
@@ -78,9 +78,9 @@
   }
 </style>
 
-<h1 class="text-center mt-4">Home</h1>
+<h1 class="text-center">Home</h1>
 
-<section class="mt-4">
+<section>
   {% if user.is_authenticated %}
   <h4 class="text-center mb-4">Welcome {{ user.username }}</h4>
   <div class="container">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/manage_notice.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/manage_notice.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
   <h2 class="text-center mb-4">Notice Board</h2>
 
   <style>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/message_detail.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/message_detail.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
     <h2 class="mb-4">{{ message.subject }}</h2>
     <p><strong>From:</strong> {{ message.sender.get_full_name|default:message.sender.username }}</p>
     <p><strong>Sent:</strong> {{ message.created_at }}</p>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/previous_bookings.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/previous_bookings.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
     <h2 class="text-center mb-4">Your Previous Bookings</h2>
 
     <div class="table-responsive">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/security_notice.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/security_notice.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5 text-center">
+<div class="container text-center">
     <h1 class="mb-4">Security Notice</h1>
     <p>
         This website is secured and undergoes regular security audits in accordance,

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/user_accounts.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/user_accounts.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
     <h2 class="text-center mb-4">User Accounts</h2>
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
     <h2 class="text-center mb-4">Previous Messages</h2>
     {% if user_messages %}
     <div class="table-responsive">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_detail.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_detail.html
@@ -1,7 +1,7 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container">
     <h2 class="mb-4">{{ workflow.name }}</h2>
     <p>Created by {{ workflow.created_by.get_full_name|default:workflow.created_by.username }} on {{ workflow.created_at }}</p>
     <ul>


### PR DESCRIPTION
## Summary
- remove per-template top margin/padding from page containers
- add global `main` padding to enforce consistent spacing across templates
- drop top margin classes from launcher, home and equipment dashboard headings and sections

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689da6570c208325b0fbb5c3aeb98a87