### PR TITLE
Align messages page styling with shared workflows

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/booking_list.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/booking_list.html
@@ -1,20 +1,9 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-{% include 'components/data_table.html' with
-title=is_superuser|yesno:'All Upcoming Bookings,Your Upcoming Bookings'
-columns=upcoming_columns
-rows=upcoming_rows
-empty_text='No upcoming bookings available.'
-row_actions='workflow_automation/partials/booking_row_actions.html'
-%}
+{% include 'components/data_table.html' with title=is_superuser|yesno:"All Upcoming Bookings,Your Upcoming Bookings" columns=upcoming_columns rows=upcoming_rows empty_text='No upcoming bookings available.' row_actions='workflow_automation/partials/booking_row_actions.html' %}
 
-{% include 'components/data_table.html' with
-title='Previous Bookings'
-columns=previous_columns
-rows=previous_rows
-empty_text='No previous bookings available.'
-%}
+{% include 'components/data_table.html' with title='Previous Bookings' columns=previous_columns rows=previous_rows empty_text='No previous bookings available.' %}
 
 <div class="text-center mt-4 mb-5">
   <form action="{% url 'previous_bookings' %}" method="post" style="display:inline;">

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/previous_bookings.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/previous_bookings.html
@@ -1,10 +1,5 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-{% include 'components/data_table.html' with
-title=is_superuser|yesno:'All Previous Bookings,Your Previous Bookings'
-columns=columns
-rows=rows
-empty_text='No previous bookings available.'
-%}
+{% include 'components/data_table.html' with title=is_superuser|yesno:"All Previous Bookings,Your Previous Bookings" columns=columns rows=rows empty_text='No previous bookings available.' %}
 {% endblock %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
@@ -1,31 +1,5 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
-<div class="container">
-    <h2 class="text-center mb-4">Previous Messages</h2>
-    {% if user_messages %}
-    <div class="table-responsive">
-        <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width:100%;">
-            <thead style="background-image: linear-gradient(to right, #05E560, #B9FF00); font-size:1.25rem; text-align:center;">
-                <tr class="text-center">
-                    <th>Subject</th>
-                    <th>Date Sent</th>
-                    <th>Message</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for msg in user_messages %}
-                <tr class="text-center">
-                    <td>{{ msg.subject }}</td>
-                    <td>{{ msg.created_at }}</td>
-                    <td>{{ msg.content|linebreaks }}</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-    {% else %}
-        <p>You have not sent any messages.</p>
-    {% endif %}
-</div>
+{% include 'components/data_table.html' with title='Previous Messages' columns=columns rows=rows empty_text='You have not sent any messages.' %}
 {% endblock %}

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from django.contrib import messages
 from django.http import HttpResponse, HttpResponseForbidden
 from django.utils import timezone
+from django.utils.html import linebreaks
 from datetime import timedelta
 from django.db.models import Q
 import os
@@ -439,7 +440,31 @@ def user_messages(request):
         Message.objects.filter(sender=request.user, workflow__isnull=True)
         .order_by('-created_at')
     )
-    return render(request, 'workflow_automation/user_messages.html', {'user_messages': msgs})
+
+    columns = [
+        {"key": "subject", "label": "Subject"},
+        {"key": "created_at", "label": "Date Sent"},
+        {"key": "content", "label": "Message"},
+    ]
+
+    rows = []
+    for m in msgs:
+        rows.append(
+            {
+                "subject": m.subject,
+                "created_at": timezone.localtime(m.created_at).strftime("%d %b %Y %H:%M"),
+                "content": linebreaks(m.content),
+            }
+        )
+
+    return render(
+        request,
+        'workflow_automation/user_messages.html',
+        {
+            'columns': columns,
+            'rows': rows,
+        },
+    )
 
 @user_passes_test(lambda u: u.is_superuser)
 def inbox(request):


### PR DESCRIPTION
## Summary
- Render bookings and messages using the shared data table component
- Fix include tags so tables display on My Bookings, Previous Bookings, and Messages pages

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689dab28478c83258e9cbd075aca83d4