### PR TITLE
Add custom 404 error page

### DIFF
--- a/equipment_booking_app/reality_capture_portal/urls.py
+++ b/equipment_booking_app/reality_capture_portal/urls.py
@@ -9,3 +9,5 @@ urlpatterns = [
     re_path(r'^(?:admin|secure-admin)/?$', automation_views.security_notice),
     path('', include('workflow_automation.urls')),
 ]
+
+handler404 = 'workflow_automation.views.page_not_found'

--- a/equipment_booking_app/workflow_automation/templates/404.html
+++ b/equipment_booking_app/workflow_automation/templates/404.html
@@ -1,0 +1,11 @@
+{% extends 'workflow_automation/base.html' %}
+
+{% block title %}Page not found{% endblock %}
+
+{% block content %}
+<div class="text-center">
+  <h1>Page Not Found</h1>
+  <p>The page you were looking for doesn't exist.</p>
+  <a href="{% url 'home' %}" class="btn btn-primary">Return Home</a>
+</div>
+{% endblock %}

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -522,3 +522,11 @@ class LauncherAccessTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn(reverse("login"), response.url)
 
+
+class NotFoundPageTests(TestCase):
+    def test_custom_404_template_used(self):
+        response = self.client.get('/nonexistent-page/')
+        self.assertEqual(response.status_code, 404)
+        self.assertTemplateUsed(response, '404.html')
+        self.assertContains(response, 'Page Not Found', status_code=404)
+

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -595,6 +595,11 @@ def security_notice(request):
     return render(request, 'workflow_automation/security_notice.html')
 
 
+def page_not_found(request, exception):
+    """Display a user-friendly 404 page for invalid URLs."""
+    return render(request, '404.html', status=404)
+
+
 @login_required
 def workflow_dashboard(request):
     workflows = Workflow.objects.filter(is_published=True)


### PR DESCRIPTION
## Summary
- add 404.html template extending site base
- wire up custom 404 handler in project URLs
- cover 404 rendering with a new test

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689db3fba8548325add62f0509f3b086