### PR TITLE
Add subtle shadow to content boxes

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -418,4 +418,5 @@ footer {
   text-align: left;
   max-height: 80vh;
   overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
 }


### PR DESCRIPTION
## Summary
- add a light box shadow to the `content-box` element for improved visual depth

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689db7df97948325ad5d0304a4b64ff5