### PR TITLE
Add inner shadow to green buttons

### DIFF
--- a/equipment_booking_app/workflow_automation/static/css/styles.css
+++ b/equipment_booking_app/workflow_automation/static/css/styles.css
@@ -252,6 +252,17 @@ h6 {
   color: #192d38 !important;
 }
 
+/* Inset shadow for green buttons */
+.btn,
+.btn-primary,
+.btn-secondary,
+.btn-success,
+.launcher-btn,
+.btn-save-changes,
+.btn-automation {
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
 /* Account details form layout */
 .account-form {
   max-width: 600px;


### PR DESCRIPTION
## Summary
- Add inset box shadow styling to all green button variants for visual depth

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689db98dd6248325afe85e3b8a20ce60