### PR TITLE
Refine sidebar links and message rendering

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -133,7 +133,7 @@
 
     /* Logout pinned at bottom, never pushes off-screen */
     #logout-link { margin-top: auto; background-color: var(--chip-bg); }
-    #sidebar.collapsed #logout-link { background-color: transparent; }
+    #sidebar.collapsed #logout-link { background-color: var(--chip-bg); }
 
     .logo { max-height:40px; margin-right:20px; }
 

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_automation.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_automation.html
@@ -48,6 +48,10 @@
                 <i class="fas fa-user-circle"></i>
                 <span class="sidebar-label">Profile</span>
             </a>
+            <a href="{% url 'user_messages' %}" class="nav-link" title="My Messages" aria-label="My Messages">
+                <i class="fas fa-envelope-open"></i>
+                <span class="sidebar-label">My Messages</span>
+            </a>
             {% if user.is_superuser %}
             <a href="{% url 'inbox' %}" class="nav-link" title="Inbox" aria-label="Inbox">
                 <i class="fas fa-inbox"></i>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_booking.html
@@ -32,10 +32,6 @@
                 <span class="sidebar-label">Contact</span>
             </a>
             {% endif %}
-            <a href="{% url 'user_messages' %}" class="nav-link" title="My Messages" aria-label="My Messages">
-                <i class="fas fa-envelope-open"></i>
-                <span class="sidebar-label">My Messages</span>
-            </a>
             {% if user.is_superuser %}
             <a href="{% url 'inbox' %}" class="nav-link" title="Inbox" aria-label="Inbox">
                 <i class="fas fa-inbox"></i>
@@ -57,6 +53,10 @@
             <a href="{% url 'accounts' %}" class="nav-link" title="Profile" aria-label="Profile">
                 <i class="fas fa-user-circle"></i>
                 <span class="sidebar-label">Profile</span>
+            </a>
+            <a href="{% url 'user_messages' %}" class="nav-link" title="My Messages" aria-label="My Messages">
+                <i class="fas fa-envelope-open"></i>
+                <span class="sidebar-label">My Messages</span>
             </a>
             <hr>
         {% else %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_launcher.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/sidebar_launcher.html
@@ -36,12 +36,6 @@
                 <i class="fas fa-share-alt"></i>
                 <span class="sidebar-label">Shared Workflows</span>
             </a>
-            {% if not user.is_superuser %}
-            <a href="{% url 'contact' %}" class="nav-link" title="Contact" aria-label="Contact">
-                <i class="fas fa-envelope"></i>
-                <span class="sidebar-label">Contact</span>
-            </a>
-            {% endif %}
             <hr>
             <span class="text-light px-3">Account</span>
             <a href="{% url 'accounts' %}" class="nav-link" title="Profile" aria-label="Profile">
@@ -49,6 +43,13 @@
                 <span class="sidebar-label">Profile</span>
             </a>
             <hr>
+            {% if not user.is_superuser %}
+            <a href="{% url 'contact' %}" class="nav-link" title="Contact" aria-label="Contact">
+                <i class="fas fa-envelope"></i>
+                <span class="sidebar-label">Contact</span>
+            </a>
+            <hr>
+            {% endif %}
         {% else %}
             <a href="{% url 'login' %}" class="nav-link" title="Login" aria-label="Login">
                 <i class="fas fa-sign-in-alt"></i>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
@@ -1,5 +1,40 @@
 {% extends 'workflow_automation/base.html' %}
 
 {% block content %}
+
+<section>
+    {% if user.is_authenticated %}
+    <div class="container">
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-md-2 row-cols-lg-4 g-3 mb-4 text-center justify-content-center">
+            <div class="col d-flex">
+                <a href="{% url 'create_booking' %}" class="btn btn-automation btn-lg flex-fill">Create Booking</a>
+            </div>
+            <div class="col d-flex">
+                <a href="{% url 'my_bookings' %}" class="btn btn-automation btn-lg flex-fill">My Bookings</a>
+            </div>
+            <div class="col d-flex">
+                <a href="{% url 'user_messages' %}" class="btn btn-automation btn-lg flex-fill">Previous Messages</a>
+            </div>
+            <div class="col d-flex">
+                <a href="{% url 'previous_bookings' %}" class="btn btn-automation btn-lg flex-fill">Previous Bookings</a>
+            </div>
+            {% if user.is_superuser %}
+            <div class="col d-flex">
+                <a href="{% url 'inbox' %}" class="btn btn-automation btn-lg flex-fill">Inbox</a>
+            </div>
+            <div class="col d-flex">
+                <a href="{% url 'user_accounts' %}" class="btn btn-automation btn-lg flex-fill">User Accounts</a>
+            </div>
+            {% endif %}
+            {% if user.is_staff %}
+            <div class="col d-flex">
+                <a href="{% url 'admin:index' %}" class="btn btn-automation btn-lg flex-fill">Admin Tools</a>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+</section>
+
 {% include 'components/data_table.html' with title='Previous Messages' columns=columns rows=rows empty_text='You have not sent any messages.' %}
 {% endblock %}

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from django.contrib import messages
 from django.http import HttpResponse, HttpResponseForbidden
 from django.utils import timezone
-from django.utils.html import linebreaks
+from django.utils.html import strip_tags
 from datetime import timedelta
 from django.db.models import Q
 import os
@@ -453,7 +453,7 @@ def user_messages(request):
             {
                 "subject": m.subject,
                 "created_at": timezone.localtime(m.created_at).strftime("%d %b %Y %H:%M"),
-                "content": linebreaks(m.content),
+                "content": strip_tags(m.content),
             }
         )
 


### PR DESCRIPTION
## Summary
- Ensure logout button retains quick link styling when sidebar is collapsed
- Strip HTML from stored messages and add booking quick links to the messages page
- Reorganize sidebars: move Contact below Account and show My Messages in account sections for all areas

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689e17a163c48325a3fbe3b7c92259ca