### PR TITLE
Display workflow progress on dashboard

### DIFF
--- a/equipment_booking_app/workflow_automation/static/js/workflow_progress.js
+++ b/equipment_booking_app/workflow_automation/static/js/workflow_progress.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', function () {
+  if (typeof RUN_ID === 'undefined' || RUN_ID === null) {
+    return;
+  }
   const bar = document.getElementById('wf-progress-bar');
   const action = document.getElementById('wf-current-action');
   const logList = document.getElementById('wf-log');

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/home.html
@@ -89,6 +89,20 @@
         <div id="demo-complete" class="alert alert-success d-none">Demo complete</div>
       </div>
 
+      <div id="wf-container" class="content-box mt-2 {% if not run_id %}d-none{% endif %}" style="color:#192d38;">
+        <div class="progress mb-3">
+          <div id="wf-progress-bar" class="progress-bar" role="progressbar" style="width:0%">0%</div>
+        </div>
+        <p id="wf-current-action" class="mb-3"></p>
+        <ul id="wf-log" class="list-group mb-3"></ul>
+        <div id="wf-error" class="alert alert-danger d-none"></div>
+        <div id="wf-complete" class="alert alert-success d-none">Complete</div>
+      </div>
+
+      <script>
+        const RUN_ID = {{ run_id|default:'null' }};
+      </script>
+      <script src="{% static 'js/workflow_progress.js' %}"></script>
       <script src="{% static 'js/demo_workflow.js' %}"></script>
     </div>
   {% else %}

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -76,8 +76,10 @@ def home(request):
         pending_count = Workflow.objects.filter(awaiting_review=True).count()
         if pending_count:
             messages.info(request, f"You have {pending_count} workflow review requests pending.")
+    run_id = request.session.pop("active_run_id", None)
     context = {
         "pending_count": pending_count,
+        "run_id": run_id,
     }
     return render(request, "workflow_automation/home.html", context)
 
@@ -1002,9 +1004,11 @@ def run_workflow(request, workflow_id=None):
                         if video_map:
                             request.session[f"run_{run.id}_video_map"] = video_map
                         request.session.modified = True
+                        request.session["active_run_id"] = run.id
                         return redirect("workflow_progress", run_id=run.id)
                     workflow_task.start_workflow(run, configs, video_map)
-                    return redirect("workflow_progress", run_id=run.id)
+                    request.session["active_run_id"] = run.id
+                    return redirect("home")
 
             # If validation fails fall through to redisplay the form
             StepFormSet = build_step_formset(workflow)


### PR DESCRIPTION
## Summary
- redirect workflow runs to the dashboard
- show workflow progress bar on the home page
- skip progress script when no workflow is active

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a1e4eee80c8325be8e4e242b545b8e