### PR TITLE
Add temporary test executable button

### DIFF
--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_dashboard.html
@@ -12,6 +12,7 @@
   <a href="{% url 'run_rename' %}" class="btn btn-brand-secondary">Run Rename Tool</a>
   <a href="{% url 'run_convert' %}" class="btn btn-brand-secondary">Run Convert Tool</a>
   <a href="{% url 'run_zip' %}" class="btn btn-brand-secondary">Run Zip Tool</a>
+  <a href="{% url 'run_x3001_test' %}" class="btn btn-danger">Run EXE Test</a>
 </div>
 
 {% if workflows %}

--- a/equipment_booking_app/workflow_automation/urls.py
+++ b/equipment_booking_app/workflow_automation/urls.py
@@ -40,6 +40,7 @@ urlpatterns = [
     path('run-rename/', views.run_rename_view, name='run_rename'),
     path('run-convert/', views.run_convert_view, name='run_convert'),
     path('run-zip/', views.run_zip_view, name='run_zip'),
+    path('run-x3001-test/', views.run_x3001_test, name='run_x3001_test'),
     path('progress-status/', views.progress_status, name='progress_status'),
     path('progress-control/', views.progress_control, name='progress_control'),
     path('messages/<int:message_id>/', views.message_detail, name='message_detail'),

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -9,7 +9,9 @@ from datetime import timedelta
 from django.db.models import Q
 import os
 import logging
+import subprocess
 from django.templatetags.static import static
+from django.conf import settings
 
 from .models import (
     Booking,
@@ -1246,6 +1248,18 @@ def run_zip_view(request):
         messages.info(request, "Zipping started")
         return redirect("run_zip")
     return render(request, "workflow_automation/run_zip.html", {"form": form})
+
+
+@login_required
+def run_x3001_test(request):
+    """Execute the temporary Renamer_x3001.exe test script."""
+    exe_path = settings.BASE_DIR.parent / "Renamer_x3001.exe"
+    try:
+        subprocess.Popen([str(exe_path)])
+        messages.info(request, "Renamer_x3001.exe executed")
+    except Exception as exc:
+        messages.error(request, f"Failed to run test executable: {exc}")
+    return redirect("workflow_dashboard")
 
 
 def progress_status(request):


### PR DESCRIPTION
## Summary
- add a temporary red button on the workflow dashboard to run Renamer_x3001.exe
- expose run_x3001_test view and URL for executing the test script

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a582d1e1b88325b8220d9025c31d75