### PR TITLE
Enable background workflow tools with dashboard progress bar

### DIFF
--- a/equipment_booking_app/utils/convert_task.py
+++ b/equipment_booking_app/utils/convert_task.py
@@ -1,0 +1,37 @@
+import os
+import threading
+import time
+from workflow_automation import file_utils
+from . import progress
+
+def _worker(input_path: str, fmt: str):
+    files = [f for f in os.listdir(input_path) if os.path.isfile(os.path.join(input_path, f))]
+    progress.start("Converting Files", input_path, input_path, files)
+    for name in files:
+        while True:
+            status = progress.get().get("status")
+            if status == "paused":
+                time.sleep(0.5)
+                continue
+            if status in {"cancel", "cancelled"}:
+                progress.set_status("cancelled")
+                return
+            break
+        progress.set_current(name)
+        src = os.path.join(input_path, name)
+        base = os.path.splitext(src)[0]
+        dst = f"{base}.{fmt}"
+        file_utils.convert_video(src, dst, fmt, original_media=src)
+        if dst != src:
+            try:
+                os.remove(src)
+            except OSError:
+                pass
+        progress.update(name)
+    progress.set_current("")
+    progress.set_status("done")
+
+def start_convert(input_path: str, fmt: str):
+    thread = threading.Thread(target=_worker, args=(input_path, fmt), daemon=True)
+    thread.start()
+    return thread

--- a/equipment_booking_app/utils/rename_task.py
+++ b/equipment_booking_app/utils/rename_task.py
@@ -1,0 +1,32 @@
+import os
+import threading
+import time
+from . import progress, rename
+
+def _worker(raw_folder: str, output_folder: str, initials: str, full_name: str, pattern: str):
+    files = [f for f in os.listdir(raw_folder) if os.path.isfile(os.path.join(raw_folder, f))]
+    progress.start("Renaming Files", raw_folder, output_folder, files)
+    renamed = rename.rename_directory(raw_folder, pattern)
+    os.makedirs(output_folder, exist_ok=True)
+    for name in renamed:
+        while True:
+            status = progress.get().get("status")
+            if status == "paused":
+                time.sleep(0.5)
+                continue
+            if status in {"cancel", "cancelled"}:
+                progress.set_status("cancelled")
+                return
+            break
+        progress.set_current(name)
+        src = os.path.join(raw_folder, name)
+        dst = os.path.join(output_folder, name)
+        os.replace(src, dst)
+        progress.update(name)
+    progress.set_current("")
+    progress.set_status("done")
+
+def start_rename(raw_folder: str, output_folder: str, initials: str, full_name: str, pattern: str = ""):
+    thread = threading.Thread(target=_worker, args=(raw_folder, output_folder, initials, full_name, pattern), daemon=True)
+    thread.start()
+    return thread

--- a/equipment_booking_app/workflow_automation/static/js/task_progress.js
+++ b/equipment_booking_app/workflow_automation/static/js/task_progress.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const container = document.getElementById('task-progress-container');
+  if (!container) return;
+  const bar = document.getElementById('task-progress-bar');
+  const current = document.getElementById('task-current');
+
+  function update() {
+    fetch('/progress-status/')
+      .then(r => r.json())
+      .then(data => {
+        if (data.status && data.status !== 'idle') {
+          container.classList.remove('d-none');
+          bar.style.width = data.percent + '%';
+          bar.textContent = data.percent + '%';
+          current.textContent = data.current_file || '';
+          if (data.status === 'done') {
+            bar.classList.add('bg-success');
+          } else if (data.status === 'cancelled') {
+            bar.classList.add('bg-danger');
+          }
+        } else {
+          container.classList.add('d-none');
+          bar.classList.remove('bg-success', 'bg-danger');
+          bar.style.width = '0%';
+          bar.textContent = '0%';
+          current.textContent = '';
+        }
+      });
+  }
+
+  update();
+  setInterval(update, 1000);
+});

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/workflow_dashboard.html
@@ -1,4 +1,5 @@
 {% extends 'workflow_automation/base.html' %}
+{% load static %}
 
 {% block content %}
 <div class="automation-header mb-4">
@@ -14,6 +15,15 @@
   <a href="{% url 'run_zip' %}" class="btn btn-brand-secondary">Run Zip Tool</a>
   <a href="{% url 'run_x3001_test' %}" class="btn btn-danger">Run EXE Test</a>
 </div>
+
+<div id="task-progress-container" class="content-box mt-2 d-none" style="color:#192d38;">
+  <div class="progress mb-3">
+    <div id="task-progress-bar" class="progress-bar" role="progressbar" style="width:0%">0%</div>
+  </div>
+  <p id="task-current" class="mb-3"></p>
+</div>
+
+<script src="{% static 'js/task_progress.js' %}"></script>
 
 {% if workflows %}
   <!-- Your Workflows (no white box) -->

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -42,7 +42,16 @@ from .forms import (
     StepSettingsForm,
 )
 
-from utils import rename, converter, zipper, progress, zip_task, workflow_task
+from utils import (
+    rename,
+    converter,
+    zipper,
+    progress,
+    zip_task,
+    workflow_task,
+    rename_task,
+    convert_task,
+)
 from django.http import JsonResponse, HttpResponseBadRequest
 from django.views.decorators.http import require_POST
 import threading
@@ -1188,10 +1197,7 @@ def run_rename_view(request):
     if not profile.initials:
         messages.error(request, "Please input your initials on the account page to continue.")
         return redirect("accounts")
-
     form = RenameToolForm(request.POST or None, initial={"user_initials": profile.initials})
-    files = []
-    selected_folder = ""
     if request.method == "POST" and form.is_valid():
         raw_folder = form.cleaned_data["raw_data_folder"]
         output_folder = form.cleaned_data["output_folder"]
@@ -1204,15 +1210,11 @@ def run_rename_view(request):
         ):
             form.add_error("raw_data_folder", "Selected folder has no valid files")
         else:
-            files = rename.run_rename(raw_folder, output_folder, initials, full_name, pattern)
-            messages.success(request, "Rename completed")
-            selected_folder = raw_folder
+            rename_task.start_rename(raw_folder, output_folder, initials, full_name, pattern)
+            messages.info(request, "Rename started")
+            return redirect("workflow_dashboard")
 
-    return render(
-        request,
-        "workflow_automation/run_rename.html",
-        {"form": form, "files": files, "raw_folder": selected_folder},
-    )
+    return render(request, "workflow_automation/run_rename.html", {"form": form})
 
 
 @login_required
@@ -1221,15 +1223,19 @@ def run_convert_view(request):
     if not profile.initials:
         messages.error(request, "Please input your initials on the account page to continue.")
         return redirect("accounts")
-
     form = ConvertToolForm(request.POST or None)
-    files = []
     if request.method == "POST" and form.is_valid():
         input_path = form.cleaned_data["input_path"]
         fmt = form.cleaned_data["format"]
-        files = converter.convert_directory(input_path, fmt)
-        messages.success(request, "Conversion completed")
-    return render(request, "workflow_automation/run_convert.html", {"form": form, "files": files})
+        if not os.path.isdir(input_path) or not any(
+            os.path.isfile(os.path.join(input_path, f)) for f in os.listdir(input_path)
+        ):
+            form.add_error("input_path", "Selected folder has no valid files")
+        else:
+            convert_task.start_convert(input_path, fmt)
+            messages.info(request, "Conversion started")
+            return redirect("workflow_dashboard")
+    return render(request, "workflow_automation/run_convert.html", {"form": form})
 
 
 @login_required
@@ -1238,15 +1244,19 @@ def run_zip_view(request):
     if not profile.initials:
         messages.error(request, "Please input your initials on the account page to continue.")
         return redirect("accounts")
-
     form = ZipToolForm(request.POST or None)
     if request.method == "POST" and form.is_valid():
         input_path = form.cleaned_data["input_path"]
         output_folder = form.cleaned_data["output_zip"]
-        os.makedirs(output_folder, exist_ok=True)
-        zip_task.start_zip(input_path, output_folder)
-        messages.info(request, "Zipping started")
-        return redirect("run_zip")
+        if not os.path.isdir(input_path) or not any(
+            os.path.isfile(os.path.join(input_path, f)) for f in os.listdir(input_path)
+        ):
+            form.add_error("input_path", "Selected folder has no valid files")
+        else:
+            os.makedirs(output_folder, exist_ok=True)
+            zip_task.start_zip(input_path, output_folder)
+            messages.info(request, "Zipping started")
+            return redirect("workflow_dashboard")
     return render(request, "workflow_automation/run_zip.html", {"form": form})
 
 


### PR DESCRIPTION
## Summary
- Run rename, convert and zip tools in background threads
- Show live progress bar on workflow dashboard
- Track rename/convert operations with new utility tasks

## Testing
- `python equipment_booking_app/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a58858d8f08325a7a193c241279b98