### PR TITLE
Normalize file paths for workflow tools

### DIFF
--- a/equipment_booking_app/utils/convert_task.py
+++ b/equipment_booking_app/utils/convert_task.py
@@ -32,6 +32,7 @@ def _worker(input_path: str, fmt: str):
     progress.set_status("done")
 
 def start_convert(input_path: str, fmt: str):
+    input_path = os.path.abspath(input_path)
     thread = threading.Thread(target=_worker, args=(input_path, fmt), daemon=True)
     thread.start()
     return thread

--- a/equipment_booking_app/utils/rename_task.py
+++ b/equipment_booking_app/utils/rename_task.py
@@ -27,6 +27,8 @@ def _worker(raw_folder: str, output_folder: str, initials: str, full_name: str, 
     progress.set_status("done")
 
 def start_rename(raw_folder: str, output_folder: str, initials: str, full_name: str, pattern: str = ""):
+    raw_folder = os.path.abspath(raw_folder)
+    output_folder = os.path.abspath(output_folder)
     thread = threading.Thread(target=_worker, args=(raw_folder, output_folder, initials, full_name, pattern), daemon=True)
     thread.start()
     return thread

--- a/equipment_booking_app/utils/zip_task.py
+++ b/equipment_booking_app/utils/zip_task.py
@@ -45,6 +45,8 @@ def _worker(rcp_pairs: list[tuple[str, str]], input_path: str, output_folder: st
 
 
 def start_zip(input_path: str, output_folder: str, completed: list[str] | None = None):
+    input_path = os.path.abspath(input_path)
+    output_folder = os.path.abspath(output_folder)
     rcp_pairs = _collect_rcp_pairs(input_path)
     file_names = [name for name, _ in rcp_pairs]
 

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_convert.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_convert.html
@@ -33,14 +33,25 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function(){
+    function getDirPath(file){
+        if (file.path){
+            const idx = file.path.lastIndexOf(file.name);
+            return file.path.substring(0, idx).replace(/[\\/]+$/, '');
+        }
+        if (file.webkitRelativePath){
+            const rel = file.webkitRelativePath;
+            const idx = rel.lastIndexOf('/');
+            return idx !== -1 ? rel.substring(0, idx) : rel;
+        }
+        return '';
+    }
     const inputPicker = document.getElementById('input_folder_picker');
     document.getElementById('input_folder_btn').addEventListener('click', function(){
         inputPicker.click();
     });
     inputPicker.addEventListener('change', function(){
         if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
+            const path = getDirPath(this.files[0]);
             document.getElementById('id_input_path').value = path;
             document.getElementById('input_folder_label').textContent = path;
         }

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
@@ -52,6 +52,18 @@
 {% endblock %}
 <script>
 document.addEventListener('DOMContentLoaded', function(){
+    function getDirPath(file){
+        if (file.path){
+            const idx = file.path.lastIndexOf(file.name);
+            return file.path.substring(0, idx).replace(/[\\/]+$/, '');
+        }
+        if (file.webkitRelativePath){
+            const rel = file.webkitRelativePath;
+            const idx = rel.lastIndexOf('/');
+            return idx !== -1 ? rel.substring(0, idx) : rel;
+        }
+        return '';
+    }
     const rawPicker = document.getElementById('raw_folder_picker');
     document.getElementById('raw_folder_btn').addEventListener('click', function(){
         rawPicker.click();
@@ -72,8 +84,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
     outputPicker.addEventListener('change', function(){
         if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
+            const path = getDirPath(this.files[0]);
             document.getElementById('id_output_folder').value = path;
             document.getElementById('output_folder_label').textContent = path;
             const base = path.replace(/[\\/]+$/, '').split(/[\\/]/).pop();
@@ -88,8 +99,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
     rawPicker.addEventListener('change', function(){
         if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
+            const path = getDirPath(this.files[0]);
             document.getElementById('id_raw_data_folder').value = path;
             document.getElementById('raw_folder_label').textContent = path;
         }

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
@@ -245,6 +245,19 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function(){
+  function getDirPath(file){
+    if (file.path){
+      const idx = file.path.lastIndexOf(file.name);
+      return file.path.substring(0, idx).replace(/[\\/]+$/, '');
+    }
+    if (file.webkitRelativePath){
+      const rel = file.webkitRelativePath;
+      const idx = rel.lastIndexOf('/');
+      return idx !== -1 ? rel.substring(0, idx) : rel;
+    }
+    return '';
+  }
+
   // Root input folder selection
   const inputPicker = document.getElementById('input_folder_picker');
   const inputBtn = document.getElementById('input_folder_btn');
@@ -253,8 +266,7 @@ document.addEventListener('DOMContentLoaded', function(){
     inputBtn.addEventListener('click', () => inputPicker.click());
     inputPicker.addEventListener('change', function(){
       if (this.files.length){
-        const file = this.files[0];
-        const path = file.path || (file.webkitRelativePath ? file.webkitRelativePath.split('/')[0] : '');
+        const path = getDirPath(this.files[0]);
         const inputField = document.getElementById('id_input_path');
         if (inputField) inputField.value = path;
         if (inputLabel) inputLabel.textContent = path;
@@ -271,8 +283,7 @@ document.addEventListener('DOMContentLoaded', function(){
     outputBtn.addEventListener('click', () => outputPicker.click());
     outputPicker.addEventListener('change', function(){
       if (this.files.length){
-        const file = this.files[0];
-        const path = file.path || (file.webkitRelativePath ? file.webkitRelativePath.split('/')[0] : '');
+        const path = getDirPath(this.files[0]);
         const outputField = document.getElementById('id_output_path');
         if (outputField) outputField.value = path;
         if (outputLabel) outputLabel.textContent = path;
@@ -297,8 +308,7 @@ document.addEventListener('DOMContentLoaded', function(){
   document.querySelectorAll('input[id^="raw_picker_"]').forEach(function(picker){
     picker.addEventListener('change', function(){
       if (this.files.length) {
-        const file = this.files[0];
-        const thePath = file.path || (file.webkitRelativePath ? file.webkitRelativePath.split('/')[0] : '');
+        const thePath = getDirPath(this.files[0]);
         const counter = this.id.split('_')[2];
         const inputId = 'id_form-' + (counter - 1) + '-raw_data_folder';
         const labelId = 'raw_label_' + counter;

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_zip.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_zip.html
@@ -28,14 +28,25 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function(){
+    function getDirPath(file){
+        if (file.path){
+            const idx = file.path.lastIndexOf(file.name);
+            return file.path.substring(0, idx).replace(/[\\/]+$/, '');
+        }
+        if (file.webkitRelativePath){
+            const rel = file.webkitRelativePath;
+            const idx = rel.lastIndexOf('/');
+            return idx !== -1 ? rel.substring(0, idx) : rel;
+        }
+        return '';
+    }
     const inputPicker = document.getElementById('input_folder_picker');
     document.getElementById('input_folder_btn').addEventListener('click', function(){
         inputPicker.click();
     });
     inputPicker.addEventListener('change', function(){
         if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
+            const path = getDirPath(this.files[0]);
             document.getElementById('id_input_path').value = path;
             document.getElementById('input_folder_label').textContent = path;
         }
@@ -47,8 +58,7 @@ document.addEventListener('DOMContentLoaded', function(){
     });
     outputPicker.addEventListener('change', function(){
         if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
+            const path = getDirPath(this.files[0]);
             document.getElementById('id_output_zip').value = path;
             document.getElementById('output_folder_label').textContent = path;
         }

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -972,8 +972,8 @@ def run_workflow(request, workflow_id=None):
             )
             if form.is_valid() and (not video_formset.is_bound or video_formset.is_valid()):
                 workflow = form.cleaned_data["workflow"]
-                input_folder = form.cleaned_data["input_path"]
-                output_folder = form.cleaned_data["output_path"]
+                input_folder = os.path.abspath(form.cleaned_data["input_path"])
+                output_folder = os.path.abspath(form.cleaned_data["output_path"])
 
                 # Build per-step config forms
                 step_forms = []
@@ -1199,8 +1199,8 @@ def run_rename_view(request):
         return redirect("accounts")
     form = RenameToolForm(request.POST or None, initial={"user_initials": profile.initials})
     if request.method == "POST" and form.is_valid():
-        raw_folder = form.cleaned_data["raw_data_folder"]
-        output_folder = form.cleaned_data["output_folder"]
+        raw_folder = os.path.abspath(form.cleaned_data["raw_data_folder"])
+        output_folder = os.path.abspath(form.cleaned_data["output_folder"])
         initials = form.cleaned_data["user_initials"]
         full_name = form.cleaned_data["full_name"]
         pattern = form.cleaned_data.get("rename_pattern", "")
@@ -1225,7 +1225,7 @@ def run_convert_view(request):
         return redirect("accounts")
     form = ConvertToolForm(request.POST or None)
     if request.method == "POST" and form.is_valid():
-        input_path = form.cleaned_data["input_path"]
+        input_path = os.path.abspath(form.cleaned_data["input_path"])
         fmt = form.cleaned_data["format"]
         if not os.path.isdir(input_path) or not any(
             os.path.isfile(os.path.join(input_path, f)) for f in os.listdir(input_path)
@@ -1246,8 +1246,8 @@ def run_zip_view(request):
         return redirect("accounts")
     form = ZipToolForm(request.POST or None)
     if request.method == "POST" and form.is_valid():
-        input_path = form.cleaned_data["input_path"]
-        output_folder = form.cleaned_data["output_zip"]
+        input_path = os.path.abspath(form.cleaned_data["input_path"])
+        output_folder = os.path.abspath(form.cleaned_data["output_zip"])
         if not os.path.isdir(input_path) or not any(
             os.path.isfile(os.path.join(input_path, f)) for f in os.listdir(input_path)
         ):

--- a/equipment_booking_app/workflow_automation/workflow_runner.py
+++ b/equipment_booking_app/workflow_automation/workflow_runner.py
@@ -27,8 +27,12 @@ class WorkflowRunner:
         use_date_suffix=False,
     ):
         self.workflow = workflow
-        self.input_path = input_path
-        self.output_path = output_path or input_path
+        # Always resolve paths to their absolute form so directory lookups
+        # are consistent regardless of the server's working directory.
+        self.input_path = os.path.abspath(input_path)
+        self.output_path = os.path.abspath(output_path) if output_path else self.input_path
+        if not os.path.isdir(self.input_path):
+            raise FileNotFoundError(f"Input path {self.input_path} does not exist")
         self.project_code = project_code
         self.initials = initials
         self.step_configs = step_configs or []


### PR DESCRIPTION
## Summary
- Resolve workflow input and output directories to absolute paths and validate existence
- Capture full directory paths in folder pickers across workflow pages
- Ensure conversion, rename, and zip tasks operate on absolute paths

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a58b7654b48325b69764164a54d46a