### PR TITLE
Add server-side directory browser with path validation

### DIFF
--- a/equipment_booking_app/reality_capture_portal/settings.py
+++ b/equipment_booking_app/reality_capture_portal/settings.py
@@ -94,3 +94,6 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Custom settings
 LOGIN_URL = 'login'
+
+# Restrict accessible filesystem locations for directory browsing
+ALLOWED_FS_ROOTS = []

--- a/equipment_booking_app/utils/paths.py
+++ b/equipment_booking_app/utils/paths.py
@@ -1,0 +1,45 @@
+import os
+import string
+from pathlib import Path
+import platform
+
+from django.conf import settings
+
+
+def list_windows_drives():
+    """Return a list of existing Windows drive letters."""
+    if platform.system().lower() != "windows":
+        return []
+    drives = []
+    for letter in string.ascii_uppercase:
+        drive = f"{letter}:" + os.sep
+        if os.path.exists(drive):
+            drives.append(drive)
+    return drives
+
+
+def resolve_user_path_or_raise(path: str) -> str:
+    """Validate and normalize a user provided path.
+
+    The path must be absolute and reside under one of the roots specified in
+    ``settings.ALLOWED_FS_ROOTS`` when that setting is non-empty.
+    """
+    if not path:
+        raise ValueError("Path is required")
+
+    p = Path(path).expanduser()
+    try:
+        p = p.resolve(strict=False)
+    except Exception as exc:  # pragma: no cover - safeguard
+        raise ValueError(str(exc))
+
+    if not p.is_absolute():
+        raise ValueError("Path must be absolute")
+
+    roots = getattr(settings, "ALLOWED_FS_ROOTS", [])
+    if roots:
+        allowed = [Path(r).expanduser().resolve(strict=False) for r in roots]
+        if not any(str(p).lower().startswith(str(r).lower()) for r in allowed):
+            raise ValueError("Path not under allowed roots")
+
+    return str(p)

--- a/equipment_booking_app/workflow_automation/forms.py
+++ b/equipment_booking_app/workflow_automation/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
+
+from utils.paths import resolve_user_path_or_raise
 from .models import Booking, Profile, Equipment, Message, Notice, Workflow, WorkflowStep
 from django.utils import timezone
 from django.contrib.auth.models import User
@@ -201,6 +203,22 @@ class RunWorkflowForm(forms.Form):
                 return profile.initials
         return self.cleaned_data.get("initials", "")
 
+    def clean_input_path(self):
+        path = self.cleaned_data.get("input_path", "")
+        try:
+            return resolve_user_path_or_raise(path)
+        except ValueError as exc:
+            raise ValidationError(str(exc))
+
+    def clean_output_path(self):
+        path = self.cleaned_data.get("output_path", "")
+        if not path:
+            return path
+        try:
+            return resolve_user_path_or_raise(path)
+        except ValueError as exc:
+            raise ValidationError(str(exc))
+
     def clean(self):
         cleaned = super().clean()
         if cleaned.get("use_input_path"):
@@ -290,15 +308,50 @@ class RenameToolForm(forms.Form):
     full_name = forms.CharField(label="Full Name", max_length=100)
     rename_pattern = forms.CharField(label="Rename Pattern", required=False)
 
+    def clean_raw_data_folder(self):
+        path = self.cleaned_data.get("raw_data_folder", "")
+        try:
+            return resolve_user_path_or_raise(path)
+        except ValueError as exc:
+            raise ValidationError(str(exc))
+
+    def clean_output_folder(self):
+        path = self.cleaned_data.get("output_folder", "")
+        try:
+            return resolve_user_path_or_raise(path)
+        except ValueError as exc:
+            raise ValidationError(str(exc))
+
 
 class ConvertToolForm(forms.Form):
     input_path = forms.CharField(label="Input Folder", max_length=255)
     format = forms.ChoiceField(label="Format", choices=[("mp4", "MP4"), ("avi", "AVI")])
 
+    def clean_input_path(self):
+        path = self.cleaned_data.get("input_path", "")
+        try:
+            return resolve_user_path_or_raise(path)
+        except ValueError as exc:
+            raise ValidationError(str(exc))
+
 
 class ZipToolForm(forms.Form):
     input_path = forms.CharField(label="Input Folder", max_length=255)
     output_zip = forms.CharField(label="Output Zip", max_length=255)
+
+    def clean_input_path(self):
+        path = self.cleaned_data.get("input_path", "")
+        try:
+            return resolve_user_path_or_raise(path)
+        except ValueError as exc:
+            raise ValidationError(str(exc))
+
+    def clean_output_zip(self):
+        path = self.cleaned_data.get("output_zip", "")
+        try:
+            return resolve_user_path_or_raise(path)
+        except ValueError as exc:
+            raise ValidationError(str(exc))
 
 
 class VideoReviewForm(forms.Form):

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/folder_browser_modal.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/folder_browser_modal.html
@@ -1,0 +1,66 @@
+<div class="modal fade" id="fsBrowserModal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Select Folder</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div id="fsCrumbs" class="mb-2 small text-muted"></div>
+        <ul id="fsDirs" class="list-group"></ul>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" id="fsChooseBtn">Choose this folder</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  let currentPath = '';
+  let targetInput = null;
+
+  function load(path){
+    let url = '/api/fs/list';
+    if(path){ url += '?path=' + encodeURIComponent(path); }
+    fetch(url).then(r => r.json()).then(data => {
+      currentPath = data.path || path || '';
+      document.getElementById('fsCrumbs').textContent = currentPath;
+      const list = document.getElementById('fsDirs');
+      list.innerHTML = '';
+      if(data.parent){
+        const up = document.createElement('li');
+        up.textContent = '..';
+        up.className = 'list-group-item';
+        up.addEventListener('click', ()=>load(data.parent));
+        list.appendChild(up);
+      }
+      (data.dirs || []).forEach(d => {
+        const li = document.createElement('li');
+        li.textContent = d;
+        li.className = 'list-group-item';
+        li.addEventListener('click', ()=>{
+          const next = currentPath ? (currentPath.replace(/[\\/]+$/, '') + '/' + d) : d;
+          load(next);
+        });
+        list.appendChild(li);
+      });
+    });
+  }
+
+  document.querySelectorAll('[data-fs-browser]').forEach(btn => {
+    btn.addEventListener('click', function(){
+      targetInput = document.getElementById(this.dataset.fsTarget);
+      load('');
+      $('#fsBrowserModal').modal('show');
+    });
+  });
+
+  document.getElementById('fsChooseBtn').addEventListener('click', function(){
+    if(targetInput){ targetInput.value = currentPath; }
+    $('#fsBrowserModal').modal('hide');
+  });
+});
+</script>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_convert.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_convert.html
@@ -5,14 +5,10 @@
 <div class="card p-4 content-box mb-4">
     <form method="post">
         {% csrf_token %}
-        <div style="display:none;">
-            {{ form.input_path }}
-        </div>
         <div class="form-group">
-            <label>Select Input Folder</label><br>
-            <input type="file" id="input_folder_picker" webkitdirectory mozdirectory directory multiple style="display:none;">
-            <button type="button" class="btn btn-secondary" id="input_folder_btn">Browse</button>
-            <span id="input_folder_label" class="ml-2"></span>
+            {{ form.input_path.label_tag }}
+            {{ form.input_path }}
+            <button type="button" class="btn btn-secondary mt-2" data-fs-browser data-fs-target="id_input_path">Browse…</button>
         </div>
         <div class="form-group">
             {{ form.format.label_tag }}
@@ -29,21 +25,5 @@
     </ul>
     {% endif %}
 </div>
+{% include 'workflow_automation/folder_browser_modal.html' %}
 {% endblock %}
-
-<script>
-document.addEventListener('DOMContentLoaded', function(){
-    const inputPicker = document.getElementById('input_folder_picker');
-    document.getElementById('input_folder_btn').addEventListener('click', function(){
-        inputPicker.click();
-    });
-    inputPicker.addEventListener('change', function(){
-        if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
-            document.getElementById('id_input_path').value = path;
-            document.getElementById('input_folder_label').textContent = path;
-        }
-    });
-});
-</script>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_rename.html
@@ -5,23 +5,17 @@
 <div class="card p-4 content-box mb-4">
     <form method="post">
         {% csrf_token %}
-        <div style="display:none;">
+
+        <div class="form-group">
+            {{ form.raw_data_folder.label_tag }}
             {{ form.raw_data_folder }}
+            <button type="button" class="btn btn-secondary mt-2" data-fs-browser data-fs-target="id_raw_data_folder">Browse…</button>
+        </div>
+
+        <div class="form-group">
+            {{ form.output_folder.label_tag }}
             {{ form.output_folder }}
-        </div>
-
-        <div class="form-group">
-            <label>Select RAW Data Folder</label><br>
-            <input type="file" id="raw_folder_picker" webkitdirectory mozdirectory directory multiple style="display:none;">
-            <button type="button" class="btn btn-secondary" id="raw_folder_btn">Browse</button>
-            <span id="raw_folder_label" class="ml-2">{{ raw_folder }}</span>
-        </div>
-
-        <div class="form-group">
-            <label>Select Output Folder</label><br>
-            <input type="file" id="output_folder_picker" webkitdirectory mozdirectory directory multiple style="display:none;">
-            <button type="button" class="btn btn-secondary" id="output_folder_btn">Browse</button>
-            <span id="output_folder_label" class="ml-2"></span>
+            <button type="button" class="btn btn-secondary mt-2" data-fs-browser data-fs-target="id_output_folder">Browse…</button>
         </div>
 
         <div id="additional-fields" style="display:none;">
@@ -48,19 +42,9 @@
         {% endfor %}
     </ul>
     {% endif %}
-</div>
-{% endblock %}
+{% include 'workflow_automation/folder_browser_modal.html' %}
 <script>
 document.addEventListener('DOMContentLoaded', function(){
-    const rawPicker = document.getElementById('raw_folder_picker');
-    document.getElementById('raw_folder_btn').addEventListener('click', function(){
-        rawPicker.click();
-    });
-
-    const outputPicker = document.getElementById('output_folder_picker');
-    document.getElementById('output_folder_btn').addEventListener('click', function(){
-        outputPicker.click();
-    });
     function checkVisibility(){
         const raw = document.getElementById('id_raw_data_folder').value;
         const out = document.getElementById('id_output_folder').value;
@@ -70,12 +54,9 @@ document.addEventListener('DOMContentLoaded', function(){
         }
     }
 
-    outputPicker.addEventListener('change', function(){
-        if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
-            document.getElementById('id_output_folder').value = path;
-            document.getElementById('output_folder_label').textContent = path;
+    document.getElementById('id_output_folder').addEventListener('input', function(){
+        const path = this.value;
+        if(path){
             const base = path.replace(/[\\/]+$/, '').split(/[\\/]/).pop();
             const suggestion = `${base}-3V-{timestamp}{ext}`;
             const renameField = document.getElementById('id_rename_pattern');
@@ -86,15 +67,8 @@ document.addEventListener('DOMContentLoaded', function(){
         checkVisibility();
     });
 
-    rawPicker.addEventListener('change', function(){
-        if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
-            document.getElementById('id_raw_data_folder').value = path;
-            document.getElementById('raw_folder_label').textContent = path;
-        }
-        checkVisibility();
-    });
+    document.getElementById('id_raw_data_folder').addEventListener('input', checkVisibility);
     checkVisibility();
 });
 </script>
+{% endblock %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_workflow.html
@@ -65,19 +65,12 @@
       </div>
     </div>
 
-    <!-- Hidden fields (kept for backend binding if needed) -->
-    <div style="display:none;">
-      {{ form.input_path }}
-      {{ form.output_path }}
-    </div>
-
     <!-- Input Folder -->
     <div class="form-row-inline">
       <label class="col-form-label label-fixed">Input Folder</label>
       <div class="field-flex d-flex align-items-center gap-8">
-        <input type="file" id="input_folder_picker" webkitdirectory mozdirectory directory multiple style="display:none;">
-        <button type="button" class="btn btn-secondary" id="input_folder_btn">Browse</button>
-        <span id="input_folder_label" class="ml-2 small text-muted">{{ input_folder }}</span>
+        {{ form.input_path }}
+        <button type="button" class="btn btn-secondary" data-fs-browser data-fs-target="id_input_path">Browse…</button>
       </div>
     </div>
 
@@ -93,9 +86,8 @@
     <div class="form-row-inline" id="output-folder-row">
       <label class="col-form-label label-fixed">Output Folder</label>
       <div class="field-flex d-flex align-items-center gap-8">
-        <input type="file" id="output_folder_picker" webkitdirectory mozdirectory directory multiple style="display:none;">
-        <button type="button" class="btn btn-secondary" id="output_folder_btn">Browse</button>
-        <span id="output_folder_label" class="ml-2 small text-muted">{{ output_folder }}</span>
+        {{ form.output_path }}
+        <button type="button" class="btn btn-secondary" data-fs-browser data-fs-target="id_output_path">Browse…</button>
       </div>
     </div>
 
@@ -121,10 +113,8 @@
           <div class="form-row-inline">
             <label class="col-form-label label-fixed">RAW Data Folder</label>
             <div class="field-flex d-flex align-items-center gap-8">
-              <input type="file" id="raw_picker_{{ forloop.counter }}" webkitdirectory mozdirectory directory multiple style="display:none;">
-              <button type="button" class="btn btn-secondary" onclick="document.getElementById('raw_picker_{{ forloop.counter }}').click()">Browse</button>
-              <span id="raw_label_{{ forloop.counter }}" class="ml-2 small text-muted"></span>
               {{ step_form.raw_data_folder }}
+              <button type="button" class="btn btn-secondary" data-fs-browser data-fs-target="id_form-{{ forloop.counter0 }}-raw_data_folder">Browse…</button>
             </div>
           </div>
           <div class="form-row-inline">
@@ -245,42 +235,7 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function(){
-  // Root input folder selection
-  const inputPicker = document.getElementById('input_folder_picker');
-  const inputBtn = document.getElementById('input_folder_btn');
-  const inputLabel = document.getElementById('input_folder_label');
-  if (inputPicker && inputBtn) {
-    inputBtn.addEventListener('click', () => inputPicker.click());
-    inputPicker.addEventListener('change', function(){
-      if (this.files.length){
-        const file = this.files[0];
-        const path = file.path || (file.webkitRelativePath ? file.webkitRelativePath.split('/')[0] : '');
-        const inputField = document.getElementById('id_input_path');
-        if (inputField) inputField.value = path;
-        if (inputLabel) inputLabel.textContent = path;
-      }
-    });
-  }
-
-  // Destination output folder selection
-  const outputPicker = document.getElementById('output_folder_picker');
-  const outputBtn = document.getElementById('output_folder_btn');
-  const outputLabel = document.getElementById('output_folder_label');
   const outputRow = document.getElementById('output-folder-row');
-  if (outputPicker && outputBtn) {
-    outputBtn.addEventListener('click', () => outputPicker.click());
-    outputPicker.addEventListener('change', function(){
-      if (this.files.length){
-        const file = this.files[0];
-        const path = file.path || (file.webkitRelativePath ? file.webkitRelativePath.split('/')[0] : '');
-        const outputField = document.getElementById('id_output_path');
-        if (outputField) outputField.value = path;
-        if (outputLabel) outputLabel.textContent = path;
-      }
-    });
-  }
-
-  // Toggle output folder based on selection
   const useInputRadios = document.querySelectorAll('input[name="use_input_path"]');
   const toggleOutput = () => {
     const selected = document.querySelector('input[name="use_input_path"]:checked');
@@ -292,23 +247,6 @@ document.addEventListener('DOMContentLoaded', function(){
   };
   useInputRadios.forEach(r => r.addEventListener('change', toggleOutput));
   toggleOutput();
-
-  // RAW folder pickers in step settings (if present)
-  document.querySelectorAll('input[id^="raw_picker_"]').forEach(function(picker){
-    picker.addEventListener('change', function(){
-      if (this.files.length) {
-        const file = this.files[0];
-        const thePath = file.path || (file.webkitRelativePath ? file.webkitRelativePath.split('/')[0] : '');
-        const counter = this.id.split('_')[2];
-        const inputId = 'id_form-' + (counter - 1) + '-raw_data_folder';
-        const labelId = 'raw_label_' + counter;
-        const input = document.getElementById(inputId);
-        if (input) input.value = thePath;
-        const label = document.getElementById(labelId);
-        if (label) label.textContent = thePath;
-      }
-    });
-  });
 
   // Drag & drop ordering for videos
   const videoList = document.getElementById('video-list');
@@ -334,4 +272,5 @@ document.addEventListener('DOMContentLoaded', function(){
   }
 });
 </script>
+{% include 'workflow_automation/folder_browser_modal.html' %}
 {% endblock %}

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/run_zip.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/run_zip.html
@@ -5,53 +5,18 @@
 <div class="card p-4 content-box mb-4">
     <form method="post">
         {% csrf_token %}
-        <div style="display:none;">
+        <div class="form-group">
+            {{ form.input_path.label_tag }}
             {{ form.input_path }}
+            <button type="button" class="btn btn-secondary mt-2" data-fs-browser data-fs-target="id_input_path">Browse…</button>
+        </div>
+        <div class="form-group">
+            {{ form.output_zip.label_tag }}
             {{ form.output_zip }}
-        </div>
-        <div class="form-group">
-            <label>Select Input Folder</label><br>
-            <input type="file" id="input_folder_picker" webkitdirectory mozdirectory directory multiple style="display:none;">
-            <button type="button" class="btn btn-secondary" id="input_folder_btn">Browse</button>
-            <span id="input_folder_label" class="ml-2"></span>
-        </div>
-        <div class="form-group">
-            <label>Select Output Folder</label><br>
-            <input type="file" id="output_folder_picker" webkitdirectory mozdirectory directory multiple style="display:none;">
-            <button type="button" class="btn btn-secondary" id="output_folder_btn">Browse</button>
-            <span id="output_folder_label" class="ml-2"></span>
+            <button type="button" class="btn btn-secondary mt-2" data-fs-browser data-fs-target="id_output_zip">Browse…</button>
         </div>
         <button type="submit" class="btn btn-primary">Run Zip</button>
     </form>
 </div>
+{% include 'workflow_automation/folder_browser_modal.html' %}
 {% endblock %}
-
-<script>
-document.addEventListener('DOMContentLoaded', function(){
-    const inputPicker = document.getElementById('input_folder_picker');
-    document.getElementById('input_folder_btn').addEventListener('click', function(){
-        inputPicker.click();
-    });
-    inputPicker.addEventListener('change', function(){
-        if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
-            document.getElementById('id_input_path').value = path;
-            document.getElementById('input_folder_label').textContent = path;
-        }
-    });
-
-    const outputPicker = document.getElementById('output_folder_picker');
-    document.getElementById('output_folder_btn').addEventListener('click', function(){
-        outputPicker.click();
-    });
-    outputPicker.addEventListener('change', function(){
-        if (this.files.length){
-            const file = this.files[0];
-            const path = file.path || file.webkitRelativePath.split('/')[0];
-            document.getElementById('id_output_zip').value = path;
-            document.getElementById('output_folder_label').textContent = path;
-        }
-    });
-});
-</script>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/start_workflow.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/start_workflow.html
@@ -1,0 +1,26 @@
+{% extends 'workflow_automation/base.html' %}
+
+{% block content %}
+<h2 class="text-center mb-4">Start Workflow Example</h2>
+<div class="card p-4 content-box mb-4">
+  <form method="post">
+    {% csrf_token %}
+    <div class="form-group">
+      {{ form.workflow.label_tag }}
+      {{ form.workflow }}
+    </div>
+    <div class="form-group">
+      {{ form.input_path.label_tag }}
+      {{ form.input_path }}
+      <button type="button" class="btn btn-secondary mt-2" data-fs-browser data-fs-target="id_input_path">Browse…</button>
+    </div>
+    <div class="form-group">
+      {{ form.output_path.label_tag }}
+      {{ form.output_path }}
+      <button type="button" class="btn btn-secondary mt-2" data-fs-browser data-fs-target="id_output_path">Browse…</button>
+    </div>
+    <button type="submit" class="btn btn-primary">Start</button>
+  </form>
+</div>
+{% include 'workflow_automation/folder_browser_modal.html' %}
+{% endblock %}

--- a/equipment_booking_app/workflow_automation/urls.py
+++ b/equipment_booking_app/workflow_automation/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from . import views
+from . import views, views_fs
 
 urlpatterns = [
     path('', views.launcher, name='launcher'),
@@ -43,5 +43,7 @@ urlpatterns = [
     path('run-x3001-test/', views.run_x3001_test, name='run_x3001_test'),
     path('progress-status/', views.progress_status, name='progress_status'),
     path('progress-control/', views.progress_control, name='progress_control'),
+    path('api/fs/list', views_fs.list_fs, name='fs_list'),
+    path('start-workflow/', views.start_workflow, name='start_workflow'),
     path('messages/<int:message_id>/', views.message_detail, name='message_detail'),
 ]

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -57,6 +57,8 @@ from django.views.decorators.http import require_POST
 import threading
 from . import file_utils
 from .log_writer import write_workflow_log
+from .workflow_runner import WorkflowRunner
+from utils.paths import resolve_user_path_or_raise
 
 # Number of allowed failed attempts before locking an account
 LOCKOUT_THRESHOLD = 5
@@ -1270,6 +1272,21 @@ def run_x3001_test(request):
     except Exception as exc:
         messages.error(request, f"Failed to run test executable: {exc}")
     return redirect("workflow_dashboard")
+
+
+@login_required
+def start_workflow(request):
+    """Simple example view demonstrating path validation with ``WorkflowRunner``."""
+    form = RunWorkflowForm(request.POST or None, user=request.user, workflow_queryset=Workflow.objects.filter(created_by=request.user))
+    if request.method == "POST" and form.is_valid():
+        workflow = form.cleaned_data["workflow"]
+        input_path = resolve_user_path_or_raise(form.cleaned_data["input_path"])
+        output_path = resolve_user_path_or_raise(form.cleaned_data["output_path"])
+        runner = WorkflowRunner(workflow, input_path, output_path)
+        runner.run()
+        messages.success(request, "Workflow started")
+        return redirect("workflow_dashboard")
+    return render(request, "workflow_automation/start_workflow.html", {"form": form})
 
 
 def progress_status(request):

--- a/equipment_booking_app/workflow_automation/views_fs.py
+++ b/equipment_booking_app/workflow_automation/views_fs.py
@@ -1,0 +1,45 @@
+import os
+from pathlib import Path
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse, Http404
+from django.views.decorators.http import require_GET
+
+from utils.paths import list_windows_drives, resolve_user_path_or_raise
+
+
+@require_GET
+@login_required
+def list_fs(request):
+    """List directories and files for a given path.
+
+    When no ``path`` query parameter is supplied, the allowed filesystem roots
+    or available Windows drives are returned.
+    """
+    user_path = request.GET.get("path")
+    if not user_path:
+        roots = getattr(settings, "ALLOWED_FS_ROOTS", [])
+        dirs = roots[:] if roots else list_windows_drives()
+        if not dirs:
+            dirs = [os.path.sep]
+        return JsonResponse({"path": "", "dirs": dirs, "files": []})
+
+    abs_path = resolve_user_path_or_raise(user_path)
+    if not os.path.isdir(abs_path):
+        raise Http404("Directory does not exist")
+
+    entries = sorted(os.listdir(abs_path))
+    dirs = [e for e in entries if os.path.isdir(os.path.join(abs_path, e))]
+    files = [e for e in entries if os.path.isfile(os.path.join(abs_path, e))]
+
+    parent = None
+    current = Path(abs_path)
+    if getattr(settings, "ALLOWED_FS_ROOTS", []):
+        allowed = [Path(r).resolve() for r in settings.ALLOWED_FS_ROOTS]
+        if current.parent != current and any(str(current.parent).lower().startswith(str(r).lower()) for r in allowed):
+            parent = str(current.parent)
+    else:
+        parent = str(current.parent) if current.parent != current else None
+
+    return JsonResponse({"path": abs_path, "parent": parent, "dirs": dirs, "files": files})

--- a/equipment_booking_app/workflow_automation/workflow_runner.py
+++ b/equipment_booking_app/workflow_automation/workflow_runner.py
@@ -3,11 +3,13 @@
 import os
 import shutil
 from datetime import datetime
+
 from . import file_utils
 from automation_core.utils.video_converter import (
     insta360_convert,
     gopro_convert,
 )
+from utils.paths import resolve_user_path_or_raise
 
 
 class WorkflowRunner:
@@ -27,8 +29,12 @@ class WorkflowRunner:
         use_date_suffix=False,
     ):
         self.workflow = workflow
-        self.input_path = input_path
-        self.output_path = output_path or input_path
+        self.input_path = resolve_user_path_or_raise(input_path)
+        self.output_path = resolve_user_path_or_raise(output_path or input_path)
+        if not os.path.isdir(self.input_path):
+            raise FileNotFoundError(f"Input path does not exist: {self.input_path}")
+        if not os.path.isdir(self.output_path):
+            raise FileNotFoundError(f"Output path does not exist: {self.output_path}")
         self.project_code = project_code
         self.initials = initials
         self.step_configs = step_configs or []


### PR DESCRIPTION
## Summary
- add reusable `resolve_user_path_or_raise` helper and Windows drive detection
- expose `/api/fs/list` for browsing allowed directories and enforce roots
- normalise workflow input/output paths and switch UI to a modal-based folder picker

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a592210c7c8325972bbfb042c7941b