### PR TITLE
Fix static asset resolution by removing duplicate paths

### DIFF
--- a/equipment_booking_app/reality_capture_portal/settings.py
+++ b/equipment_booking_app/reality_capture_portal/settings.py
@@ -84,10 +84,13 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'workflow_automation/static'),
-]
+# Django already locates `static/` directories inside each app via
+# ``AppDirectoriesFinder``. Including ``workflow_automation/static`` in
+# ``STATICFILES_DIRS`` caused every asset to be discovered twice, leading to
+# warnings during ``collectstatic`` and 404s when one of the duplicates was
+# skipped. Clearing the list avoids the duplication and lets Django serve the
+# app's static files normally.
+STATICFILES_DIRS: list[str] = []
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'


### PR DESCRIPTION
## Summary
- Remove redundant `STATICFILES_DIRS` entry that was causing static files to be discovered twice.
- Rely on app-level `static/` directories to serve assets reliably.

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py check`
- `python manage.py runserver 0.0.0.0:8000 &` and `curl -I http://localhost:8000/static/images/Open%20side%20bar%20Logo.png`


------
https://chatgpt.com/codex/tasks/task_e_68a5a4f0a7208325afefce24c8eaf8b9