### PR TITLE
Remove binary database change from shared workflow updates

### DIFF
--- a/equipment_booking_app/workflow_automation/migrations/0036_unpublish_mp4_shared_workflow.py
+++ b/equipment_booking_app/workflow_automation/migrations/0036_unpublish_mp4_shared_workflow.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+def unpublish_mp4_workflow(apps, schema_editor):
+    Workflow = apps.get_model("bookings", "Workflow")
+    (Workflow.objects
+        .filter(name__iexact="MP4", is_published=True)
+        .update(is_published=False, published_by=None, published_at=None))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bookings", "0035_rename_step_type_workflowstep_action"),
+    ]
+
+    operations = [
+        migrations.RunPython(unpublish_mp4_workflow, migrations.RunPython.noop),
+    ]

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/base.html
@@ -147,6 +147,11 @@
     }
     .nav-link:hover { background-color:#1f3b49; color:#fff; }
 
+    /* ====== Button grid helper ====== */
+    .button-grid > [class*='col'] {
+      margin-bottom: 1rem;
+    }
+
     /* ====== GREEN BUTTON SYSTEM (site-wide sheen & glow) ======
        Applies to all green buttons except .btn-danger and .btn-link. */
     .btn:not(.btn-danger):not(.btn-link),

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/equipment_dashboard.html
@@ -8,7 +8,7 @@
         <h4 class="text-center mb-4">Welcome {{ user.username }}</h4>
 
         <div class="container">
-            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-2 row-cols-lg-4 g-3 mb-4 text-center justify-content-center">
+            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-2 row-cols-lg-4 button-grid mb-4 text-center justify-content-center">
                 <div class="col d-flex">
                     <a href="{% url 'create_booking' %}" class="btn btn-automation btn-lg flex-fill">Create Booking</a>
                 </div>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/shared_workflow_row_actions.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/partials/shared_workflow_row_actions.html
@@ -1,4 +1,12 @@
-<form method="post" action="{% url 'use_shared_workflow' row.id %}" class="d-inline">
-  {% csrf_token %}
-  <button type="submit" class="btn btn-sm btn-primary">Download</button>
-</form>
+<div class="d-flex flex-wrap align-items-center">
+  <form method="post" action="{% url 'use_shared_workflow' row.id %}" class="mr-2 mb-2">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-sm btn-primary">Download</button>
+  </form>
+  {% if request.user.is_staff %}
+    <form method="post" action="{% url 'delete_shared_workflow' row.id %}" class="mb-2" onsubmit="return confirm('Remove this shared workflow?');">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+    </form>
+  {% endif %}
+</div>

--- a/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
+++ b/equipment_booking_app/workflow_automation/templates/workflow_automation/user_messages.html
@@ -5,7 +5,7 @@
 <section>
     {% if user.is_authenticated %}
     <div class="container">
-        <div class="row row-cols-1 row-cols-sm-2 row-cols-md-2 row-cols-lg-4 g-3 mb-4 text-center justify-content-center">
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-md-2 row-cols-lg-4 button-grid mb-4 text-center justify-content-center">
             <div class="col d-flex">
                 <a href="{% url 'create_booking' %}" class="btn btn-automation btn-lg flex-fill">Create Booking</a>
             </div>

--- a/equipment_booking_app/workflow_automation/tests.py
+++ b/equipment_booking_app/workflow_automation/tests.py
@@ -468,6 +468,34 @@ class WorkflowDeleteTests(TestCase):
         self.assertFalse(Workflow.objects.filter(id=self.wf.id).exists())
 
 
+class SharedWorkflowAdminActionsTests(TestCase):
+    def setUp(self):
+        self.publisher = User.objects.create_user(username="publisher", password="pass")
+        self.staff = User.objects.create_user(username="staff", password="pass", is_staff=True)
+        self.regular = User.objects.create_user(username="regular", password="pass")
+        self.workflow = Workflow.objects.create(
+            name="Shared",
+            created_by=self.publisher,
+            is_published=True,
+            published_by=self.publisher,
+        )
+
+    def test_staff_can_remove_shared_workflow(self):
+        self.client.force_login(self.staff)
+        response = self.client.post(reverse("delete_shared_workflow", args=[self.workflow.id]))
+        self.assertRedirects(response, reverse("shared_workflows"))
+        self.workflow.refresh_from_db()
+        self.assertFalse(self.workflow.is_published)
+        self.assertIsNone(self.workflow.published_by)
+
+    def test_regular_user_cannot_remove_shared_workflow(self):
+        self.client.force_login(self.regular)
+        response = self.client.post(reverse("delete_shared_workflow", args=[self.workflow.id]))
+        self.assertEqual(response.status_code, 403)
+        self.workflow.refresh_from_db()
+        self.assertTrue(self.workflow.is_published)
+
+
 class MessageResponseTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(

--- a/equipment_booking_app/workflow_automation/urls.py
+++ b/equipment_booking_app/workflow_automation/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path('demo/video-preview/', views.demo_video_review, name='demo_video_preview'),
     path('workflows/mine/', views.my_workflows, name='my_workflows'),
     path('workflows/shared/', views.shared_workflow_list_view, name='shared_workflows'),
+    path('workflows/<int:workflow_id>/delete-shared/', views.delete_shared_workflow, name='delete_shared_workflow'),
     path('workflows/<int:workflow_id>/request-review/', views.request_review, name='request_review'),
     path('workflows/review/', views.review_workflows, name='review_workflows'),
     path('workflows/detail/<int:workflow_id>/', views.workflow_detail, name='workflow_detail'),

--- a/equipment_booking_app/workflow_automation/views.py
+++ b/equipment_booking_app/workflow_automation/views.py
@@ -880,6 +880,22 @@ shared_workflows = shared_workflow_list_view
 
 
 @login_required
+def delete_shared_workflow(request, workflow_id):
+    if not request.user.is_staff:
+        return HttpResponseForbidden("You are not allowed to delete shared workflows.")
+    if request.method != "POST":
+        return HttpResponseBadRequest("Invalid request method.")
+
+    workflow = get_object_or_404(Workflow, id=workflow_id, is_published=True)
+    workflow.is_published = False
+    workflow.published_by = None
+    workflow.published_at = None
+    workflow.save(update_fields=["is_published", "published_by", "published_at"])
+    messages.success(request, f"Shared workflow '{workflow.name}' has been removed.")
+    return redirect("shared_workflows")
+
+
+@login_required
 def use_shared_workflow(request, workflow_id):
     workflow = get_object_or_404(Workflow, id=workflow_id, is_published=True)
     workflow.downloaded_by.add(request.user)


### PR DESCRIPTION
## Summary
- add a reusable button-grid helper and apply it to the equipment and messages dashboards so stacked admin buttons have spacing
- expose a staff-only delete endpoint and UI button so shared workflows can be removed through the app, and cover the behaviour with regression tests
- add a data migration that unpublishes the stray MP4 shared workflow instead of editing the bundled SQLite database

## Testing
- python equipment_booking_app/manage.py test workflow_automation

------
https://chatgpt.com/codex/tasks/task_e_68dceb51c91483258d7933167509ae14